### PR TITLE
Fix Edit Profile - Fix padding for input with prepend

### DIFF
--- a/src/components/form/inputs/TextInput.tsx
+++ b/src/components/form/inputs/TextInput.tsx
@@ -81,7 +81,7 @@ export default function TextInput({
   const [active, setActive] = useState<boolean>(false);
   const color = colors['light'];
 
-  const padStyle = prepend ? { paddingLeft: 0 } : {};
+  const padStyle = prepend && active ? { paddingLeft: 0 } : {};
   return (
     <OuterContainer color={color}>
       <FieldEnv

--- a/src/people/widgetViews/__tests__/EditOrgModal.spec.tsx
+++ b/src/people/widgetViews/__tests__/EditOrgModal.spec.tsx
@@ -49,7 +49,7 @@ describe('EditOrgModal Component', () => {
   test('Padding for the Github repo text field should not be 0', () => {
     render(<EditOrgModal {...props} />);
     expect(screen.getByLabelText(/Github repo/i)).not.toHaveStyle('padding: 0');
-  })
+  });
 
   test('displays the Description box', () => {
     render(<EditOrgModal {...props} />);

--- a/src/people/widgetViews/__tests__/EditOrgModal.spec.tsx
+++ b/src/people/widgetViews/__tests__/EditOrgModal.spec.tsx
@@ -46,6 +46,11 @@ describe('EditOrgModal Component', () => {
     expect(screen.getAllByText(/Github repo/i)).toHaveLength(2);
   });
 
+  test('Padding for the Github repo text field should not be 0', () => {
+    render(<EditOrgModal {...props} />);
+    expect(screen.getByLabelText(/Github repo/i)).not.toHaveStyle('padding: 0');
+  })
+
   test('displays the Description box', () => {
     render(<EditOrgModal {...props} />);
     expect(screen.getAllByText(/Description/i)).toHaveLength(2);


### PR DESCRIPTION
## Describe your changes
I have fixed the padding issue on the profile update page.
This would solve the issue with all inputs. The handling of the left padding is incorrect for input tag.

## Issue ticket number and link
https://github.com/stakwork/sphinx-tribes-frontend/issues/2

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have tested on a mobile device
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend