### PR TITLE
fix:Enable delete button after unassigning a hunter

### DIFF
--- a/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
@@ -449,6 +449,8 @@ function MobileView(props: CodingBountiesProps) {
     );
   }
 
+  const isDisabled = !(isAssigned || paid) ? false : true;
+
   return (
     <div>
       {hasAccess ? (
@@ -563,7 +565,7 @@ function MobileView(props: CodingBountiesProps) {
                             leadingImageContainerStyle={{
                               left: 450
                             }}
-                            disabled={!props?.deleteAction}
+                            disabled={isDisabled}
                             buttonAction={props?.deleteAction}
                             buttonTextStyle={{
                               paddingRight: '45px'

--- a/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
@@ -147,4 +147,18 @@ describe('MobileView component', () => {
 
     expect(screen.getByText(nameTagProps.owner_alias)).toBeInTheDocument();
   });
+
+  it('Should disable the delete bounty button if a hunter is assigned or not paid', () => {
+    defaultProps.isAssigned = true;
+    render(<MobileView {...defaultProps} />);
+    const deleteButton = screen.findByText('Delete');
+    expect(deleteButton).toBeDisabled();
+  });
+
+  it('Should click the delete button if there is no assigned hunter to the bounty', () => {
+    defaultProps.isAssigned = false;
+    render(<MobileView {...defaultProps} />);
+    const deleteButton = screen.findByText('Delete');
+    expect(deleteButton).toBeEnabled();
+  });
 });


### PR DESCRIPTION
## Describe your changes
Fixed delete button when a hunter is unassigned 
added unit test src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx


## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend

https://github.com/stakwork/sphinx-tribes-frontend/assets/34518489/9a027f3a-7e00-463b-99f0-21b90cdc62b7


