### PR TITLE
fix:Enable delete button after unassigning a hunter

### DIFF
--- a/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
@@ -450,7 +450,7 @@ function MobileView(props: CodingBountiesProps) {
     );
   }
 
-  const isDisabled = !(isAssigned || paid) ? false : true;
+  const isDisabled = isAssigned || paid;
 
   return (
     <div>

--- a/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
@@ -450,6 +450,8 @@ function MobileView(props: CodingBountiesProps) {
     );
   }
 
+  const isDisabled = !(isAssigned || paid) ? false : true;
+
   return (
     <div>
       {hasAccess ? (
@@ -564,7 +566,7 @@ function MobileView(props: CodingBountiesProps) {
                             leadingImageContainerStyle={{
                               left: 450
                             }}
-                            disabled={!props?.deleteAction}
+                            disabled={isDisabled}
                             buttonAction={props?.deleteAction}
                             buttonTextStyle={{
                               paddingRight: '45px'

--- a/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
@@ -5,6 +5,28 @@ import React from 'react';
 import NameTag from 'people/utils/NameTag';
 import MobileView from '../CodingBounty';
 
+interface Props {
+  isDisabled: boolean;
+  buttonText: string;
+}
+
+const ImageButton = ({ isDisabled, buttonText }: Props) => (
+  <div
+    role="button"
+    style={{
+      width: '117px',
+      height: '40px'
+    }}
+  >
+    <div className="leadingImageContainer">
+      <img className="buttonImage" src="/static/Delete.svg" alt="h" />
+    </div>
+    <button disabled={isDisabled} className="euiText ButtonText css-g2xc3e-euiText-m">
+      {buttonText}
+    </button>
+  </div>
+);
+
 describe('MobileView component', () => {
   beforeEach(() => {
     const mockIntersectionObserver = jest.fn();
@@ -162,5 +184,23 @@ describe('MobileView component', () => {
 
     const completionDate = screen.getByText('Jan 26, 2024');
     expect(completionDate).toBeInTheDocument();
+  });
+
+  it('Should disable the delete bounty button if a hunter is assigned to te bounty', () => {
+    defaultProps.isAssigned = true;
+    const isDisabled = defaultProps.isAssigned;
+    render(<ImageButton buttonText={'Delete'} isDisabled={isDisabled} />);
+
+    const deleteButton = screen.getByText('Delete');
+    expect(deleteButton).toBeDisabled();
+  });
+
+  it('Should be enabled the delete button if there is no assigned hunter to the bounty', () => {
+    defaultProps.isAssigned = false;
+    const isDisabled = defaultProps.isAssigned;
+    render(<ImageButton buttonText={'Delete'} isDisabled={isDisabled} />);
+
+    const deleteButton = screen.getByText('Delete');
+    expect(deleteButton).toBeEnabled();
   });
 });


### PR DESCRIPTION
Describe your changes
Fixed delete button when a hunter is unassigned 
added unit test src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend

https://github.com/stakwork/sphinx-tribes/issues/1127

https://github.com/stakwork/sphinx-tribes-frontend/assets/34518489/9a027f3a-7e00-463b-99f0-21b90cdc62b7