### PR TITLE
Tribes Page: Fix Copy link button overflowing text

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -756,7 +756,6 @@ textarea.qr-string {
 
 .copy-btn {
   background: #698cf7;
-  width: 62px;
   height: 25px;
   font-size: 10px;
   border-radius: 5px;


### PR DESCRIPTION
## Issue ticket number and link
https://github.com/stakwork/sphinx-tribes-frontend/issues/53

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested on Chrome
- [ ] I have provided a screenshot of changes in my PR if there were updates to the frontend