### PR TITLE
fix the alignment issue in people page

### DIFF
--- a/src/people/main/Body.tsx
+++ b/src/people/main/Body.tsx
@@ -35,9 +35,11 @@ const Body = styled.div<{ isMobile: boolean }>`
     display: flex;
     flex-wrap: wrap;
     height: 100%;
-    justify-content: flex-start;
+    justify-content: center;
     align-items: flex-start;
-    padding: 0px 20px 20px 20px;
+    margin-left: 20px;
+    margin-right: 20px;
+    padding-right: 13px;
   }
 `;
 
@@ -122,7 +124,7 @@ function BodyComponent() {
 
   if (loading) {
     return (
-      <Body isMobile={isMobile} style={{ justifyContent: 'center', alignItems: 'center' }}>
+      <Body data-testid="content" isMobile={isMobile}>
         <EuiLoadingSpinner size="xl" />
       </Body>
     );

--- a/src/people/main/__tests__/Body.spec.tsx
+++ b/src/people/main/__tests__/Body.spec.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import nock from 'nock';
+import { user } from '../../../__test__/__mockData__/user';
+import BodyComponent from '../Body';
+
+beforeAll(() => {
+  nock.disableNetConnect();
+});
+
+describe('BodyComponent', () => {
+  nock(user.url)
+    .get(`/people?page=1&resetPage=true&search=&sortBy=last_login&limit=500`)
+    .reply(200, {});
+
+  it('content element has equal left and right margins', () => {
+    render(<BodyComponent />);
+
+    const contentElement = screen.getByTestId('content');
+
+    expect(contentElement).toBeInTheDocument();
+
+    const styles = window.getComputedStyle(contentElement);
+
+    const { marginLeft, marginRight } = styles;
+
+    expect(marginLeft).toEqual(marginRight);
+  });
+});


### PR DESCRIPTION
## What the Problem :
-There is excess margin on the right side of the people section. Additionally, all components in this section will look better if they were aligned in the center.

## Issue ticket number and link
- Issue number: #56
- issue [Link](https://github.com/stakwork/sphinx-tribes-frontend/issues/56)

## Evidence: 
![image](https://github.com/stakwork/sphinx-tribes-frontend/assets/122393878/2f258e5f-3f39-4ac3-8d22-65cb8ce7e851)

## Type of change:
- The changes to the CSS in the .content selector involve centering the content horizontally, adding equal left and right margins of 20px, and adjusting the right padding to 13px for improved styling.

- A new test case for the `BodyComponent` in the React application. The added test ensures that the `content` element within the component has equal left and right margins, contributing to a balanced layout. The test uses the `@testing-library/react` and `@testing-library/jest-dom` libraries for effective component testing. By validating the margin equality, we aim to enhance the consistency and visual appeal of the component's design. This addition helps maintain a robust testing suite for the `BodyComponent`.