### PR TITLE
Make people profile space consistent 

### DIFF
--- a/src/pages/people/Person.tsx
+++ b/src/pages/people/Person.tsx
@@ -197,7 +197,7 @@ export default function Person(props: PersonProps) {
             <div style={{ height: 210 }}>
               <Img style={{ height: '100%', width: '100%', borderRadius: 0 }} src={img} />
             </div>
-            <div style={{ padding: 16 }}>
+            <div style={{ padding: 11 }}>
               <DTitle>{owner_alias}</DTitle>
               {description && description !== 'description' && (
                 <DDescription>{description}</DDescription>

--- a/src/pages/tickets/__tests__/TicketModalPage.spec.tsx
+++ b/src/pages/tickets/__tests__/TicketModalPage.spec.tsx
@@ -35,25 +35,6 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('TicketModalPage Component', () => {
-  it('should redirect to the appropriate page on close based on the route', async () => {
-    (useIsMobile as jest.Mock).mockReturnValue(false);
-
-    jest.spyOn(mainStore, 'getBountyById');
-    jest.spyOn(mainStore, 'getBountyIndexById');
-
-    render(<TicketModalPage setConnectPerson={jest.fn()} visible={true} />);
-
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    await waitFor(() => {});
-
-    const closeButton = screen.queryByTestId('close-btn');
-    if (closeButton) {
-      fireEvent.click(closeButton);
-
-      expect(mockPush).toHaveBeenCalledWith('/bounties');
-    }
-  });
-
   beforeEach(() => {
     const mockIntersectionObserver = jest.fn();
     mockIntersectionObserver.mockReturnValue({
@@ -148,5 +129,23 @@ describe('TicketModalPage Component', () => {
       expect(getByText(mockBountiesMutated[1].body.description)).toBeInTheDocument();
       expect(getByText(formatSat(Number(mockBountiesMutated[1].body.price)))).toBeInTheDocument();
     });
+  });
+  it('should redirect to the appropriate page on close based on the route', async () => {
+    (useIsMobile as jest.Mock).mockReturnValue(false);
+
+    jest.spyOn(mainStore, 'getBountyById');
+    jest.spyOn(mainStore, 'getBountyIndexById');
+
+    render(<TicketModalPage setConnectPerson={jest.fn()} visible={true} />);
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    await waitFor(() => {});
+
+    const closeButton = screen.queryByTestId('close-btn');
+    if (closeButton) {
+      fireEvent.click(closeButton);
+
+      expect(mockPush).toHaveBeenCalledWith('/bounties');
+    }
   });
 });


### PR DESCRIPTION
inconsistent space between description and connect button in profile model on people page is fixed. issue #108
![Screenshot profile](https://github.com/stakwork/sphinx-tribes-frontend/assets/110402767/ee5b4f7d-b909-44b5-9186-9dfea50b77a1)

 