### PR TITLE
Fix: the issue where the page reloads when switching users

### DIFF
--- a/src/pages/people/Person.tsx
+++ b/src/pages/people/Person.tsx
@@ -135,7 +135,10 @@ export default function Person(props: PersonProps) {
         <a
           href={`/p/${owner_pubkey}`}
           // The "select" method will navigate to a new person page while retaining the "href" attribute for SEO purposes.
-          onClick={(e: React.MouseEvent<HTMLAnchorElement>) => { e.preventDefault(); e.stopPropagation(); }}
+          onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
           style={{ textDecoration: 'none', color: 'inherit', cursor: 'pointer' }}
         >
           <div
@@ -194,10 +197,15 @@ export default function Person(props: PersonProps) {
       <a
         href={`/p/${owner_pubkey}`}
         // The "select" method will navigate to a new person page while retaining the "href" attribute for SEO purposes.
-        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => { e.preventDefault(); e.stopPropagation(); }}
+        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
         style={{ textDecoration: 'none', color: 'inherit', cursor: 'pointer' }}
       >
-        <DWrap squeeze={squeeze} onClick={() => select(id, unique_name, owner_pubkey)}
+        <DWrap
+          squeeze={squeeze}
+          onClick={() => select(id, unique_name, owner_pubkey)}
           data-testid="person-card-desktop"
         >
           <div>

--- a/src/pages/people/Person.tsx
+++ b/src/pages/people/Person.tsx
@@ -135,12 +135,13 @@ export default function Person(props: PersonProps) {
         <a
           href={`/p/${owner_pubkey}`}
           // the select props will jump to new person page, keep href for SEO
-          onClick={(e: React.MouseEvent<HTMLAnchorElement>) => { e.preventDefault(); }}
+          onClick={(e: React.MouseEvent<HTMLAnchorElement>) => { e.preventDefault(); e.stopPropagation(); }}
           style={{ textDecoration: 'none', color: 'inherit', cursor: 'pointer' }}
         >
           <div
             style={{ background: selected ? '#F2F3F5' : '#fff', cursor: 'pointer' }}
             onClick={() => select(id, unique_name, owner_pubkey)}
+            data-testid="person-card-small"
           >
             <Wrap style={{ padding: hideActions ? 10 : 25 }}>
               <div>
@@ -193,10 +194,12 @@ export default function Person(props: PersonProps) {
       <a
         href={`/p/${owner_pubkey}`}
         // the select props will jump to new person page, keep href for SEO
-        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => { e.preventDefault(); }}
+        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => { e.preventDefault(); e.stopPropagation(); }}
         style={{ textDecoration: 'none', color: 'inherit', cursor: 'pointer' }}
       >
-        <DWrap squeeze={squeeze} onClick={() => select(id, unique_name, owner_pubkey)}>
+        <DWrap squeeze={squeeze} onClick={() => select(id, unique_name, owner_pubkey)}
+          data-testid="person-card-desktop"
+        >
           <div>
             <div style={{ height: 210 }}>
               <Img style={{ height: '100%', width: '100%', borderRadius: 0 }} src={img} />
@@ -222,6 +225,7 @@ export default function Person(props: PersonProps) {
                     iconSize={16}
                     onClick={(e: any) => {
                       setShowQR(true);
+                      e.preventDefault();
                       e.stopPropagation();
                     }}
                   />

--- a/src/pages/people/Person.tsx
+++ b/src/pages/people/Person.tsx
@@ -134,7 +134,7 @@ export default function Person(props: PersonProps) {
       return (
         <a
           href={`/p/${owner_pubkey}`}
-          // the select props will jump to new person page, keep href for SEO
+          // The "select" method will navigate to a new person page while retaining the "href" attribute for SEO purposes.
           onClick={(e: React.MouseEvent<HTMLAnchorElement>) => { e.preventDefault(); e.stopPropagation(); }}
           style={{ textDecoration: 'none', color: 'inherit', cursor: 'pointer' }}
         >
@@ -193,7 +193,7 @@ export default function Person(props: PersonProps) {
     return (
       <a
         href={`/p/${owner_pubkey}`}
-        // the select props will jump to new person page, keep href for SEO
+        // The "select" method will navigate to a new person page while retaining the "href" attribute for SEO purposes.
         onClick={(e: React.MouseEvent<HTMLAnchorElement>) => { e.preventDefault(); e.stopPropagation(); }}
         style={{ textDecoration: 'none', color: 'inherit', cursor: 'pointer' }}
       >
@@ -225,7 +225,7 @@ export default function Person(props: PersonProps) {
                     iconSize={16}
                     onClick={(e: any) => {
                       setShowQR(true);
-                      e.preventDefault();
+                      e.preventDefault(); // Do not navigate to a new page when displaying the QR code modal
                       e.stopPropagation();
                     }}
                   />

--- a/src/pages/people/Person.tsx
+++ b/src/pages/people/Person.tsx
@@ -134,6 +134,8 @@ export default function Person(props: PersonProps) {
       return (
         <a
           href={`/p/${owner_pubkey}`}
+          // the select props will jump to new person page, keep href for SEO
+          onClick={(e: React.MouseEvent<HTMLAnchorElement>) => { e.preventDefault(); }}
           style={{ textDecoration: 'none', color: 'inherit', cursor: 'pointer' }}
         >
           <div
@@ -190,6 +192,8 @@ export default function Person(props: PersonProps) {
     return (
       <a
         href={`/p/${owner_pubkey}`}
+        // the select props will jump to new person page, keep href for SEO
+        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => { e.preventDefault(); }}
         style={{ textDecoration: 'none', color: 'inherit', cursor: 'pointer' }}
       >
         <DWrap squeeze={squeeze} onClick={() => select(id, unique_name, owner_pubkey)}>

--- a/src/pages/people/__tests__/Person.spec.tsx
+++ b/src/pages/people/__tests__/Person.spec.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom'
+import Person from '../Person';
+
+const mockUser = {
+  id: 1,
+  img: 'https://community.sphinx.chat/static/avatarPlaceholders/placeholder_35.jpg',
+  owner_alias: 'user1',
+  owner_pubkey: 'xxxxx',
+  unique_name: 'user1',
+  squeeze: false,
+  description: 'hello, I am user1',
+  tags: ['Javascript', 'PHP'],
+  photo_url: 'https://community.sphinx.chat/static/avatarPlaceholders/placeholder_35.jpg',
+  alias: 'user1',
+  route_hint: '',
+  contact_key: '',
+  price_to_meet: 0,
+  url: '',
+  verification_signature: '',
+  extras: {
+
+  }
+}
+
+describe('Person component', () => {
+  beforeEach(() => {
+    const mockIntersectionObserver = jest.fn();
+    mockIntersectionObserver.mockReturnValue({
+      observe: () => null,
+      unobserve: () => null,
+      disconnect: () => null
+    });
+    window.IntersectionObserver = mockIntersectionObserver;
+  })
+
+  it('should call select method when user is clicked and the page will not triger window.onload', () => {
+    const onloadSpy = jest.fn();
+    const selectMock = jest.fn();
+
+    const { getByTestId } = render(
+      <Person
+        {...mockUser}
+        hideActions={true}
+        small={true}
+        selected={false}
+        select={selectMock}
+      />
+    );
+
+    const personCard = getByTestId('person-card-small');
+    fireEvent.click(personCard);
+
+    window.onload = onloadSpy;
+    expect(onloadSpy).not.toHaveBeenCalled();
+    expect(selectMock).toHaveBeenCalledWith(mockUser.id, mockUser.unique_name, mockUser.owner_pubkey);
+  });
+
+  it('should show user contect qrcode modal when contect is clicked', async () => {
+    const selectMock = jest.fn();
+
+    const { getByText, getByTestId } = render(
+      <Person
+        {...mockUser}
+        hideActions={false}
+        small={false}
+        selected={false}
+        select={selectMock}
+      />
+    );
+
+    const connectBtn = getByText('Connect');
+    fireEvent.click(connectBtn); // click contect button and show qrcode modal
+
+    expect(getByTestId('connect-modal')).toBeInTheDocument();
+    expect(getByTestId('testid-qrcode')).toBeInTheDocument();
+    expect(selectMock).not.toHaveBeenCalled()
+  });
+});

--- a/src/pages/people/__tests__/Person.spec.tsx
+++ b/src/pages/people/__tests__/Person.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom';
 import Person from '../Person';
 
 const mockUser = {
@@ -19,10 +19,8 @@ const mockUser = {
   price_to_meet: 0,
   url: '',
   verification_signature: '',
-  extras: {
-
-  }
-}
+  extras: {}
+};
 
 describe('Person component', () => {
   beforeEach(() => {
@@ -33,20 +31,14 @@ describe('Person component', () => {
       disconnect: () => null
     });
     window.IntersectionObserver = mockIntersectionObserver;
-  })
+  });
 
   it('should call select method when user is clicked and the page will not triger window.onload', () => {
     const onloadSpy = jest.fn();
     const selectMock = jest.fn();
 
     const { getByTestId } = render(
-      <Person
-        {...mockUser}
-        hideActions={true}
-        small={true}
-        selected={false}
-        select={selectMock}
-      />
+      <Person {...mockUser} hideActions={true} small={true} selected={false} select={selectMock} />
     );
 
     const personCard = getByTestId('person-card-small');
@@ -54,7 +46,11 @@ describe('Person component', () => {
 
     window.onload = onloadSpy;
     expect(onloadSpy).not.toHaveBeenCalled();
-    expect(selectMock).toHaveBeenCalledWith(mockUser.id, mockUser.unique_name, mockUser.owner_pubkey);
+    expect(selectMock).toHaveBeenCalledWith(
+      mockUser.id,
+      mockUser.unique_name,
+      mockUser.owner_pubkey
+    );
   });
 
   it('should show user contect qrcode modal when contect is clicked', async () => {
@@ -75,6 +71,6 @@ describe('Person component', () => {
 
     expect(getByTestId('connect-modal')).toBeInTheDocument();
     expect(getByTestId('testid-qrcode')).toBeInTheDocument();
-    expect(selectMock).not.toHaveBeenCalled()
+    expect(selectMock).not.toHaveBeenCalled();
   });
 });

--- a/src/people/utils/ConnectCard.tsx
+++ b/src/people/utils/ConnectCard.tsx
@@ -101,7 +101,10 @@ export default function ConnectCard(props: ConnectCardProps) {
         }}
         visible={visible}
       >
-        <div style={{ textAlign: 'center', paddingTop: 59, width: 310 }} data-testid="connect-modal">
+        <div
+          style={{ textAlign: 'center', paddingTop: 59, width: 310 }}
+          data-testid="connect-modal"
+        >
           <ImgWrap>
             <W color={color}>
               <Icon src={person?.img || '/static/person_placeholder.png'} />
@@ -115,7 +118,7 @@ export default function ConnectCard(props: ConnectCardProps) {
               <B>{person?.owner_alias} </B>
             </D>
 
-            <QR value={qrString} size={210} type={'connect'}/>
+            <QR value={qrString} size={210} type={'connect'} />
 
             <>
               {person?.owner_pubkey && (

--- a/src/people/utils/ConnectCard.tsx
+++ b/src/people/utils/ConnectCard.tsx
@@ -101,7 +101,7 @@ export default function ConnectCard(props: ConnectCardProps) {
         }}
         visible={visible}
       >
-        <div style={{ textAlign: 'center', paddingTop: 59, width: 310 }}>
+        <div style={{ textAlign: 'center', paddingTop: 59, width: 310 }} data-testid="connect-modal">
           <ImgWrap>
             <W color={color}>
               <Icon src={person?.img || '/static/person_placeholder.png'} />
@@ -115,7 +115,7 @@ export default function ConnectCard(props: ConnectCardProps) {
               <B>{person?.owner_alias} </B>
             </D>
 
-            <QR value={qrString} size={210} type={'connect'} />
+            <QR value={qrString} size={210} type={'connect'}/>
 
             <>
               {person?.owner_pubkey && (


### PR DESCRIPTION
## Describe your changes
Fix the issue of page reload caused by <a> tag href navigation.
Fix the problem where clicking the "connect" button displays the QR code modal and simultaneously navigates to a new page

## Issue ticket number and link

#146 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend
- [x]  I've created a test that asserts the page doesn't reload when switching profiles

https://www.loom.com/share/11fa17f9407a4fdfbb023da651f1055a?sid=a3e6c32f-824d-411d-b923-a88de42f5bc6