### PR TITLE
Implement `Sort By` Filter on Organization Homepage

### DIFF
--- a/src/pages/tickets/org/orgHeader/index.tsx
+++ b/src/pages/tickets/org/orgHeader/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { EuiCheckboxGroup, EuiPopover, EuiText } from '@elastic/eui';
 import MaterialIcon from '@material/react-material-icon';
 import { PostModal } from 'people/widgetViews/postBounty/PostModal';
@@ -25,7 +25,6 @@ import {
   FillContainer,
   FilterLabel,
   Filters,
-  FiltersLeft,
   FiltersRight,
   Header,
   Icon,
@@ -42,7 +41,6 @@ import {
   SecondaryText,
   SkillContainer,
   SkillFilter,
-  SoryByContainer,
   StatusContainer,
   UrlButton,
   UrlButtonContainer
@@ -53,6 +51,17 @@ const color = colors['light'];
 const Coding_Languages = GetValue(coding_languages);
 
 const Status = ['Open', 'Assigned', 'Completed', 'Paid'];
+
+const sortDirectionOptions = [
+  {
+    id: 'desc',
+    label: 'Newest First'
+  },
+  {
+    id: 'asc',
+    label: 'Oldest First'
+  }
+];
 export const OrgHeader = ({
   onChangeLanguage,
   checkboxIdToSelectedMapLanguage,
@@ -67,10 +76,23 @@ export const OrgHeader = ({
   const [filterClick, setFilterClick] = useState(false);
   const [canPostBounty, setCanPostBounty] = useState(false);
   const [isStatusPopoverOpen, setIsStatusPopoverOpen] = useState<boolean>(false);
+  const [isSortByPopoverOpen, setIsSortByPopoverOpen] = useState(false);
+  const [sortDirection, setSortDirection] = useState<string>('desc');
   const onButtonClick = async () => {
     setIsStatusPopoverOpen((isPopoverOpen: any) => !isPopoverOpen);
   };
   const closeStatusPopover = () => setIsStatusPopoverOpen(false);
+
+  const sortDirectionLabel = useMemo(
+    () => (sortDirection === 'asc' ? 'Oldest First' : 'Newest First'),
+    [sortDirection]
+  );
+
+  const onSortButtonClick = async () => {
+    setIsSortByPopoverOpen((isPopoverOpen: any) => !isPopoverOpen);
+  };
+
+  const closeSortByPopover = () => setIsSortByPopoverOpen(false);
 
   useEffect(() => {
     const checkUserPermissions = async () => {
@@ -109,10 +131,11 @@ export const OrgHeader = ({
         page: 1,
         resetPage: true,
         ...checkboxIdToSelectedMap,
-        languageString
+        languageString,
+        direction: sortDirection
       });
     }
-  }, [org_uuid, checkboxIdToSelectedMap, main, languageString]);
+  }, [org_uuid, checkboxIdToSelectedMap, main, languageString, sortDirection]);
 
   const { name, img, description, website, github } = organizationData;
 
@@ -134,7 +157,7 @@ export const OrgHeader = ({
     return () => {
       window.removeEventListener('click', handleWindowClick);
     };
-  }, [filterClick]);
+  }, [org_uuid, checkboxIdToSelectedMap, languageString, main, filterClick]);
 
   return (
     <>
@@ -222,7 +245,7 @@ export const OrgHeader = ({
                 <div
                   style={{
                     display: 'flex',
-                    flexDirection: 'row'
+                    flex: 'row'
                   }}
                 >
                   <EuiPopOverCheckbox className="CheckboxOuter" color={color}>
@@ -266,14 +289,61 @@ export const OrgHeader = ({
               <Icon src={searchIcon} alt="Search" />
             </SearchWrapper>
           </FiltersRight>
-          <FiltersLeft>
-            <SoryByContainer>
-              <FilterLabel>Sort by:Newest First</FilterLabel>
-              <DropDownButton>
-                <Img src={dropdown} alt="" />
-              </DropDownButton>
-            </SoryByContainer>
-          </FiltersLeft>
+          <EuiPopover
+            button={
+              <StatusContainer onClick={onSortButtonClick} className="CheckboxOuter" color={color}>
+                <div style={{ minWidth: '145px' }}>
+                  <EuiText
+                    className="statusText"
+                    style={{
+                      color: isSortByPopoverOpen ? color.grayish.G10 : ''
+                    }}
+                  >
+                    Sort By: {sortDirectionLabel}
+                  </EuiText>
+                </div>
+
+                <div className="filterStatusIconContainer">
+                  <MaterialIcon
+                    className="materialStatusIcon"
+                    icon={`${isSortByPopoverOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}`}
+                    style={{
+                      color: isSortByPopoverOpen ? color.grayish.G10 : ''
+                    }}
+                  />
+                </div>
+              </StatusContainer>
+            }
+            panelStyle={{
+              border: 'none',
+              boxShadow: `0px 1px 20px ${color.black90}`,
+              background: `${color.pureWhite}`,
+              borderRadius: '0px 0px 6px 6px',
+              maxWidth: '140px',
+              marginTop: '0px',
+              marginRight: '30px'
+            }}
+            isOpen={isSortByPopoverOpen}
+            closePopover={closeSortByPopover}
+            panelClassName="yourClassNameHere"
+            panelPaddingSize="none"
+            anchorPosition="downLeft"
+          >
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'row'
+              }}
+            >
+              <EuiPopOverCheckbox className="CheckboxOuter" color={color}>
+                <EuiCheckboxGroup
+                  options={sortDirectionOptions}
+                  idToSelectedMap={{ [sortDirection]: true }}
+                  onChange={(id: string) => setSortDirection(id)}
+                />
+              </EuiPopOverCheckbox>
+            </div>
+          </EuiPopover>
         </Filters>
       </FillContainer>
       <NumberOfBounties>

--- a/src/people/interfaces.ts
+++ b/src/people/interfaces.ts
@@ -427,6 +427,7 @@ export interface OrgBountyHeaderProps {
   languageString?: string;
   org_uuid?: string;
   organizationData: Organization;
+  direction?: string;
 }
 export interface PeopleHeaderProps {
   onChangeLanguage: (number) => void;

--- a/src/people/widgetViews/__tests__/OrgHeader.spec.tsx
+++ b/src/people/widgetViews/__tests__/OrgHeader.spec.tsx
@@ -36,6 +36,7 @@ const MockProps: OrgBountyHeaderProps = {
     Completed: false
   },
   languageString: '',
+  direction: 'desc',
   org_uuid: 'clf6qmo4nncmf23du7ng',
   onChangeStatus: jest.fn(),
   onChangeLanguage: jest.fn(),
@@ -117,12 +118,43 @@ describe('OrgHeader Component', () => {
     expect(statusOpenCheckbox).toBeInTheDocument();
     fireEvent.click(statusOpenCheckbox);
 
-    waitFor(() => {
+    waitFor(async () => {
       expect(MockProps.onChangeStatus).toHaveBeenCalledWith('Open');
+
+      await waitFor(() => {
+        fireEvent.click(screen.getByText(/Sort By:/i));
+      });
+
+      const newestFirstOption = screen.getByText('Newest First');
+      fireEvent.click(newestFirstOption);
+
+      await waitFor(() => {
+        expect(mainStore.getSpecificOrganizationBounties).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            direction: 'desc'
+          })
+        );
+
+        jest.clearAllMocks();
+
+        const oldestFirstOption = screen.getByText('Oldest First');
+        fireEvent.click(oldestFirstOption);
+      });
+
+      await waitFor(() => {
+        expect(mainStore.getSpecificOrganizationBounties).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            direction: 'asc'
+          })
+        );
+      });
 
       const updatedCheckboxIdToSelectedMap = {
         ...MockProps.checkboxIdToSelectedMap,
-        Open: true
+        Open: true,
+        direction: 'desc'
       };
 
       rerender(


### PR DESCRIPTION
### Problem:
The organization homepage currently lacks a `Sort By` filter, which is essential for users to easily navigate and find bounties according to their creation date. The absence of this feature limits user experience and efficiency in sorting through available bounties.

### Expected Behavior:
Implementing a `Sort By` filter on the organization homepage will enhance user experience by allowing users to sort bounties based on their creation date. The filter will include two options: `Newest first` and `Oldest First`. `Newest first` will be set as the default. When a user selects an option, it should trigger the appropriate API call with the correct parameters, updating the list of bounties accordingly. Additionally, the text next to `Sort by` should update to reflect the selected option, and the text field should expand to the left if necessary. The default filter view should display all bounties, regardless of status or skills, sorted by the newest bounty first.

## Issue ticket number and link:
- **Ticket Number:** [ 1326 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes/issues/1326 ]

### Evidence:
 Please see the attached video as evidence.
https://www.loom.com/share/4025623401984c9985e7c187a7ec35d9

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have successfully tested the feature on Chrome, confirming that the "Sort By" filter operates as expected across different scenarios.
- [x] I have added a comprehensive unit test that verifies the correct API call is made.