### PR TITLE
fix(main): correct typo in request parameters

### DIFF
--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -684,7 +684,7 @@ export class MainStore {
       limit: String(limit),
       ...(queryParams?.resetPage ? { resetPage: String(queryParams.resetPage) } : {}),
       ...(queryParams?.page ? { page: String(queryParams.page) } : {}),
-      ...(queryParams?.languages ? { langauges: queryParams.languages } : {})
+      ...(queryParams?.languages ? { languages: queryParams.languages } : {})
     } as Record<string, string>;
 
     const searchParams = new URLSearchParams(adaptedParams);


### PR DESCRIPTION
Correct type in lang**au**ges request parameter

lang**au**ges → lang**ua**ges

Relates: #1

Small bug fix. while pass `languages` in query object parameters, in final request was present two parameters, 'languages' and 'langauges'