### PR TITLE
ci: cancel running docker build if new PR is merged

### DIFF
--- a/.github/workflows/build_on_master_merge.yml
+++ b/.github/workflows/build_on_master_merge.yml
@@ -7,6 +7,16 @@ on:
     branch:
       - master
 
+# https://docs.github.com/en/actions/learn-github-actions/expressions
+# https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+concurrency:
+  # github.workflow: name of the workflow
+  # github.event.pull_request.number || github.ref: pull request number or branch name if not a pull request
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Describe your changes
If we merge a PR and then merge another one right after we want to stop the previous one so we don't miss features in the master docker image
## Issue ticket number and link
none
## Type of change
ci/cd