### PR TITLE
Remove Character Restriction in Bounty Editing Modal

### DIFF
--- a/src/components/form/bounty/index.tsx
+++ b/src/components/form/bounty/index.tsx
@@ -224,7 +224,7 @@ function Form(props: FormProps) {
                   <Input
                     {...item}
                     key={item.name}
-                    newDesign={true}
+                    newDesign={item.name === 'description' ? false : true}
                     values={values}
                     setAssigneefunction={item.name === 'assignee' && setAssigneeName}
                     peopleList={peopleList}


### PR DESCRIPTION
### Problem:
When attempting to edit a bounty, users encounter a character limit restriction. This issue likely stems from an inconsistency in handling character limits between the "edit bounty" and "edit organization" modals. This restriction impedes users' ability to fully describe or update the bounty details, potentially affecting the clarity and effectiveness of the bounty's description.

### Expected Behavior:
The expected behavior is for users to have the ability to edit a bounty without facing a character limit. 

## Issue ticket number and link:
- **Ticket Number:** [ 156 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/156 ]

### Evidence:
 Please see the attached video as evidence.
 https://www.loom.com/share/55c680e9894a421089af0e210fa675c3

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend