### PR TITLE
Fix Horizontal Alignment of Logo and Organization Name on Org Homepage

### DIFF
--- a/src/pages/tickets/org/orgHeader/OrgHeaderStyles.tsx
+++ b/src/pages/tickets/org/orgHeader/OrgHeaderStyles.tsx
@@ -130,7 +130,7 @@ export const CompanyLabel = styled.p`
   font-size: 28px;
   font-style: normal;
   font-weight: 700;
-  margin-top: 10px;
+  margin: 2px;
   display: flex;
   align-items: center;
 `;

--- a/src/pages/tickets/org/orgHeader/OrgHeaderStyles.tsx
+++ b/src/pages/tickets/org/orgHeader/OrgHeaderStyles.tsx
@@ -121,6 +121,7 @@ export const Leftheader = styled.div`
 export const CompanyNameAndLink = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
 `;
 
 export const CompanyLabel = styled.p`
@@ -129,6 +130,9 @@ export const CompanyLabel = styled.p`
   font-size: 28px;
   font-style: normal;
   font-weight: 700;
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
 `;
 export const ImageContainer = styled.img`
   width: 72px;


### PR DESCRIPTION
### Problem:
The logo and organization name on the organization homepage were not aligned horizontally when website or GitHub links were not provided, causing a visual inconsistency and detracting from the user interface's aesthetic appeal. The logo and organization name on the organization homepage were not aligned horizontally when website or GitHub links were not provided, causing a visual inconsistency and detracting from the user interface's aesthetic appeal.

### Expected Behavior:
The organization logo and name should align horizontally across all instances, regardless of the presence or absence of website or GitHub links.

## Issue ticket number and link:
- **Ticket Number:** [ 209 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/209 ]

### Solution:
Adjusted the CSS for the `CompanyNameAndLink`, and `CompanyLabel` components to utilize flexbox properties effectively, ensuring that the logo and organization name are always centered relative to each other. This solution provides a consistent layout regardless of additional content.

### Changes:
- Updated `CompanyNameAndLink` with justify-content: center to vertically center the content.
- Adjusted `CompanyLabel` to remove default margins and apply display: flex and align-items: center for precise vertical and horizontal alignment with the logo.

### Evidence:
 Please see the attached video as evidence.
https://www.loom.com/share/21b6d5173abb4e87bbcc6a1512e4b76e

### Testing:

**Browser Compatibility:**
- Tested the feature extensively on Chrome to ensure consistent behavior.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested on Chrome
- [x] I have provided a recording.