### PR TITLE
label overlapping dropdown fixed

### DIFF
--- a/src/components/common/CreatableMultiSelect.tsx
+++ b/src/components/common/CreatableMultiSelect.tsx
@@ -20,7 +20,7 @@ const S = styled(CreatableSelect)<styledProps>`
   user-select: none;
   font-size: 12px;
   border-width: 0px !important;
-
+  z-index: 900;
   #react-select-10-listbox {
     z-index: 1000;
   }
@@ -65,7 +65,6 @@ const S = styled(CreatableSelect)<styledProps>`
 export default function Sel(props: SelProps) {
   const { onChange, value, style, setIsTop } = props;
   const color = colors['light'];
-
   const opts =
     colourOptions.map((o: any) => ({
       value: o.value,
@@ -97,6 +96,7 @@ export default function Sel(props: SelProps) {
           option: (styles: any) => ({
             ...styles,
             backgroundColor: '#fff',
+
             color: color.text2,
             fontFamily: 'Barlow',
             fontSize: '14px',

--- a/src/components/common/MultiSelect.tsx
+++ b/src/components/common/MultiSelect.tsx
@@ -9,57 +9,57 @@ interface styledProps {
 }
 
 const S = styled(Select)<styledProps>`
-background:#ffffff00;
-border: 1px solid ${(p: any) => p.color && p.color.grayish.G750};
-color: ${(p: any) => p.color && p.color.pureBlack};
-box-sizing: border-box;
-box-shadow:none;
-border: none !important;
-user-select:none;
-font-size:12px;
-border-width:0px !important;
+  background: #ffffff00;
+  border: 1px solid ${(p: any) => p.color && p.color.grayish.G750};
+  color: ${(p: any) => p.color && p.color.pureBlack};
+  box-sizing: border-box;
+  box-shadow: none;
+  border: none !important;
+  user-select: none;
+  font-size: 12px;
+  border-width: 0px !important;
+  z-index: 909;
 
-#react-select-10-listbox{
-    z-index:1000;
-}
-#react-select-9-listbox{
-    z-index:1000;
-}
-#react-select-8-listbox{
-    z-index:1000;
-}
-#react-select-7-listbox{
-    z-index:1000;
-}
-#react-select-6-listbox{
-    z-index:1000;
-}
-#react-select-5-listbox{
-    z-index:1000;
-}
-#react-select-4-listbox{
-    z-index:1000;
-}
-#react-select-3-listbox{
-    z-index:1000;
-}
-#react-select-2-listbox{
-    z-index:1000;
-}
-#react-select-1-listbox{
-    z-index:1000;
-}
+  #react-select-10-listbox {
+    z-index: 1000;
+  }
+  #react-select-9-listbox {
+    z-index: 1000;
+  }
+  #react-select-8-listbox {
+    z-index: 1000;
+  }
+  #react-select-7-listbox {
+    z-index: 1000;
+  }
+  #react-select-6-listbox {
+    z-index: 1000;
+  }
+  #react-select-5-listbox {
+    z-index: 1000;
+  }
+  #react-select-4-listbox {
+    z-index: 1000;
+  }
+  #react-select-3-listbox {
+    z-index: 1000;
+  }
+  #react-select-2-listbox {
+    z-index: 1000;
+  }
+  #react-select-1-listbox {
+    z-index: 1000;
+  }
 
-div {
-    border-width:0px !important;
+  div {
+    border-width: 0px !important;
     border: none !important;
-}
+  }
 
-button {
+  button {
     background: ${(p: any) => p.color && p.color.pureWhite} !important;
     background-color: ${(p: any) => p.color && p.color.pureWhite} !important;
-}
-}
+  }
 `;
 export default function Sel(props: SelProps) {
   const { options, onChange, value, style } = props;

--- a/src/components/form/inputs/CreatableMultiSelectInput.tsx
+++ b/src/components/form/inputs/CreatableMultiSelectInput.tsx
@@ -58,7 +58,7 @@ export default function CreatableMultiSelectInput({
       >
         <R>
           <CreatableMultiSelect
-            selectStyle={{ border: 'none' }}
+            selectStyle={{ border: 'none', zIndex: '999' }}
             options={options}
             writeMode={type === 'multiselectwrite'}
             value={value}

--- a/src/components/form/inputs/index.tsx
+++ b/src/components/form/inputs/index.tsx
@@ -58,6 +58,7 @@ interface fieldEnvProps {
   height?: any;
   width?: any;
   isTextField?: any;
+  label?: string;
 }
 
 export const FieldEnv = styled(EuiFormRow as any)<fieldEnvProps>`
@@ -85,7 +86,8 @@ export const FieldEnv = styled(EuiFormRow as any)<fieldEnvProps>`
     label {
       color: ${(p: any) => p?.color && p.color.grayish.G300} !important;
       background: ${(p: any) => p?.color && p.color.pureWhite};
-      z-index: 10;
+      z-index: ${(p: any) =>
+        p?.label === 'Tribes' ? 910 : p?.label === 'Coding Languages' ? 902 : 10};
       position: ${(p: any) => p?.isTop && 'absolute'};
       top: ${(p: any) => p?.isTop && '-20px'} !important;
       font-family: 'Barlow';


### PR DESCRIPTION
In edit profile label of input boxes overlapping dropdown list fixed.
Fixed dropdowns when editing a profile so it doesn't get covered by elements below.

issue #225

https://www.loom.com/share/d6d8b46234e7454881cef8aa82e50dad?sid=d94bbcb3-0704-4396-90b4-a3f530eff9b5