### PR TITLE
Fix `Custom` Date Range Text Display in Dropdown

### DIFF
--- a/src/pages/superadmin/header/__tests__/SuperAdminHeader.spec.tsx
+++ b/src/pages/superadmin/header/__tests__/SuperAdminHeader.spec.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen, within, act } from '@testing-library/react';
+import { render, screen, within, act, fireEvent } from '@testing-library/react';
 import moment from 'moment';
 import nock from 'nock';
 import React from 'react';
@@ -188,5 +188,26 @@ describe('Header Component', () => {
     expect(monthElement).toHaveTextContent(expectedTextContent);
 
     expect(screen.getByText(exportCSVText)).toBeInTheDocument();
+  });
+  test('displays "Custom" when dates are selected', async () => {
+    const setStartDateMock = jest.fn();
+    const setEndDateMock = jest.fn();
+
+    render(
+      <Header
+        startDate={moment().subtract(7, 'days').startOf('day').unix()}
+        endDate={moment().startOf('day').unix()}
+        setStartDate={setStartDateMock}
+        setEndDate={setEndDateMock}
+      />
+    );
+
+    const dropDownButton = screen.getByTestId('DropDown');
+    fireEvent.click(dropDownButton);
+
+    const customOption = screen.getByText('Custom');
+    fireEvent.click(customOption);
+
+    expect(dropDownButton).toHaveTextContent('Custom');
   });
 });

--- a/src/pages/superadmin/header/index.tsx
+++ b/src/pages/superadmin/header/index.tsx
@@ -30,6 +30,7 @@ export const Header = ({ startDate, setStartDate, endDate, setEndDate }: HeaderP
   const [dateDiff, setDateDiff] = useState(7);
   const [exportLoading, setExportLoading] = useState(false);
   const [showCalendar, setShowCalendar] = useState(false);
+  const [dropdownText, setDropdownText] = useState<string>('Last 7 Days');
   const formatUnixDate = (unixDate: number) => {
     const formatString = 'DD MMM YYYY';
     if (startDate !== undefined && endDate !== undefined) {
@@ -77,27 +78,34 @@ export const Header = ({ startDate, setStartDate, endDate, setEndDate }: HeaderP
     setExportLoading(false);
   };
 
-  const handleDropDownChange = (option: number) => {
-    const selectedValue = Number(option);
-    setDateDiff(selectedValue);
-
-    if (startDate && endDate) {
-      const currentEndDate = moment.unix(endDate);
-      let newStartDate;
-
-      if (selectedValue === 7) {
-        newStartDate = currentEndDate.clone().subtract(option, 'days').unix();
-      } else if (selectedValue === 30) {
-        newStartDate = currentEndDate.clone().subtract(option, 'days').unix();
-      } else if (selectedValue === 90) {
-        newStartDate = currentEndDate.clone().subtract(option, 'days').unix();
+  const handleDropDownChange = (option: number | string) => {
+    if (typeof option === 'number') {
+      const selectedValue = Number(option);
+      setDateDiff(selectedValue);
+      let text = `${selectedValue} Days`;
+      switch (selectedValue) {
+        case 7:
+          text = 'Last 7 Days';
+          break;
+        case 30:
+          text = 'Last 30 Days';
+          break;
+        case 90:
+          text = 'Last 90 Days';
+          break;
+        default:
+          break;
       }
-      newStartDate = Math.max(
-        newStartDate,
-        currentEndDate.clone().subtract(selectedValue, 'days').unix()
-      );
+      setDropdownText(text);
 
-      setStartDate(newStartDate);
+      if (startDate && endDate) {
+        const currentEndDate = moment.unix(endDate);
+        const newStartDate = currentEndDate.clone().subtract(selectedValue, 'days').unix();
+        setStartDate(newStartDate);
+      }
+    } else if (option === 'Custom') {
+      setDropdownText('Custom');
+      setShowCalendar(!showCalendar);
     }
   };
 
@@ -154,7 +162,7 @@ export const Header = ({ startDate, setStartDate, endDate, setEndDate }: HeaderP
               setShowSelector(!showSelector);
             }}
           >
-            Last {dateDiff} Days
+            <div style={{ flex: 2, textAlign: 'center' }}>{dropdownText}</div>
             <div>
               <img src={expand_more} alt="a" />
             </div>
@@ -165,7 +173,7 @@ export const Header = ({ startDate, setStartDate, endDate, setEndDate }: HeaderP
                   <li onClick={() => handleDropDownChange(30)}>30 Days</li>
                   <li onClick={() => handleDropDownChange(90)}>90 Days</li>
                   <li>
-                    <CustomButton onClick={() => setShowCalendar(!showCalendar)}>
+                    <CustomButton onClick={() => handleDropDownChange('Custom')}>
                       Custom
                     </CustomButton>
                   </li>


### PR DESCRIPTION
### Problem:
Users reported a bug where changing the date range to a custom selection did not update the dropdown text to `"Custom"` as expected. This issue was observed in the `superadmin` interface, affecting usability and user experience.

### Expected Behavior:
Upon selecting a custom date range, the dropdown text should dynamically change to `"Custom"` to reflect the user's action accurately. This change provides clear feedback that a custom date range has been applied.

## Issue ticket number and link:
- **Ticket Number:** [ 113 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/113 ]

### Solution:
The solution involved updating the `handleDropDownChange` function to correctly update the state that controls the dropdown text when the `"Custom"` option is selected. This ensures that the dropdown text accurately reflects the user's selection.

### Changes:
- Modified the `handleDropDownChange` function in the Header component to set the dropdown text to `"Custom"` when a custom date range is selected.
- Ensured that the dropdown text state updates correctly in all scenarios, including predefined ranges and custom date selection.
- Updated the dropdown component to reflect the new state when "Custom" is selected, ensuring the UI is immediately updated.

### Evidence:
 Please see the attached video as evidence.
https://www.loom.com/share/730d7bbc1b4b49b9a3a14f87fab30437

### Testing:

**Browser Compatibility:**
- Tested the feature extensively on Chrome to ensure consistent behavior.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] I have tested on a mobile device
- [x] I have provided a recording of the changes in my PR
- [x] I have added unit tests.