### PR TITLE
Fixed Prevent Unwanted Spaces in Bounty Fields During Creation

### DIFF
--- a/src/components/form/bounty/bountyCreation.spec.tsx
+++ b/src/components/form/bounty/bountyCreation.spec.tsx
@@ -1,0 +1,78 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { wantedCodingTaskSchema } from '../schema.ts';
+import Form from './index.tsx';
+
+describe('Bounty index', () => {
+  beforeEach(async () => {
+    act(async () => {
+      render(<Form onSubmit={jest.fn()} schema={wantedCodingTaskSchema} />);
+      const PostBountyButton = await screen.findByRole('button', { name: /Post a Bounty/i });
+      expect(PostBountyButton).toBeInTheDocument();
+      fireEvent.click(PostBountyButton);
+      const StartButton = await screen.findByRole('button', { name: /Start/i });
+      expect(StartButton).toBeInTheDocument();
+    });
+  });
+
+  test('Form does not proceed when only spaces are entered in title', async () => {
+    act(async () => {
+      const bountyTitleInput = await screen.findByRole('input', { name: /Bounty Title/i });
+      fireEvent.change(bountyTitleInput, { target: { value: '                ' } });
+
+      const dropdown = screen.getByText(/Category /i);
+      fireEvent.click(dropdown);
+      const desiredOption = screen.getByText(/Web Development/i);
+      fireEvent.click(desiredOption);
+
+      const nextButton = await screen.findByRole('button', { name: /Next/i });
+      fireEvent.click(nextButton);
+      expect(nextButton).toBeDisabled();
+    });
+  });
+
+  test('Form does not proceed when only spaces are entered in description', async () => {
+    act(async () => {
+      const bountyTitleInput = await screen.findByRole('input', { name: /Bounty Title/i });
+      fireEvent.change(bountyTitleInput, { target: { value: 'Test The Bounty' } });
+
+      const dropdown = screen.getByText(/Category /i);
+      fireEvent.click(dropdown);
+      const desiredOption = screen.getByText(/Web Development/i);
+      fireEvent.click(desiredOption);
+
+      const nextButton = await screen.findByRole('button', { name: /Next/i });
+      fireEvent.click(nextButton);
+
+      const descriptionInput = await screen.findByRole('input', { name: /Description/i });
+      fireEvent.change(descriptionInput, { target: { value: '              ' } });
+
+      const nextButton2 = await screen.findByRole('button', { name: /Next/i });
+      fireEvent.click(nextButton2);
+      expect(nextButton2).toBeDisabled();
+    });
+  });
+
+  test('Spaces are trimmed from bounty title and description', async () => {
+    act(async () => {
+      const bountyTitleInput = await screen.findByRole('input', { name: /Bounty Title/i });
+      fireEvent.change(bountyTitleInput, { target: { value: '   Te st Ti tle   ' } });
+
+      const descriptionInput = await screen.findByRole('input', { name: /Description/i });
+      fireEvent.change(descriptionInput, { target: { value: '   Te st Descri ption   ' } });
+
+      const mockOnSubmit = jest.fn();
+      render(<Form onSubmit={mockOnSubmit} schema={wantedCodingTaskSchema} />);
+
+      const submitButton = await screen.findByRole('button', { name: /Next/i });
+      fireEvent.click(submitButton);
+
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Test Title',
+          description: 'Test Description'
+        })
+      );
+    });
+  });
+});

--- a/src/components/form/inputs/TextAreaInput.tsx
+++ b/src/components/form/inputs/TextAreaInput.tsx
@@ -102,7 +102,7 @@ export default function TextAreaInput({
 
   const handleTextBlur = (e: any) => {
     const normalizedText = normalizeAndTrimText(e.target.value);
-    handleChange(normalizedText); // Update the text with normalized spaces on blur
+    handleChange(normalizedText);
     handleBlur(e);
     setActive(false);
   };

--- a/src/components/form/inputs/TextAreaInput.tsx
+++ b/src/components/form/inputs/TextAreaInput.tsx
@@ -91,6 +91,22 @@ export default function TextAreaInput({
   const color = colors['light'];
   if (error) labeltext = `${labeltext} (${error})`;
   const [active, setActive] = useState<boolean>(false);
+  const normalizeAndTrimText = (text: string) => {
+    return text.split('\n').join('\n');
+  };
+
+  const handleTextChange = (e: any) => {
+    const newText = normalizeAndTrimText(e.target.value.trimStart());
+    handleChange(newText);
+  };
+
+  const handleTextBlur = (e: any) => {
+    const normalizedText = normalizeAndTrimText(e.target.value);
+    handleChange(normalizedText); // Update the text with normalized spaces on blur
+    handleBlur(e);
+    setActive(false);
+  };
+
   return (
     <OuterContainer color={color}>
       <FieldEnv
@@ -112,11 +128,8 @@ export default function TextAreaInput({
             name="first"
             value={value || ''}
             readOnly={readOnly || false}
-            onChange={(e: any) => handleChange(e.target.value)}
-            onBlur={(e: any) => {
-              handleBlur(e);
-              setActive(false);
-            }}
+            onChange={handleTextChange}
+            onBlur={handleTextBlur}
             onFocus={(e: any) => {
               handleFocus(e);
               setActive(true);

--- a/src/components/form/inputs/TextAreaInputNew.tsx
+++ b/src/components/form/inputs/TextAreaInputNew.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { colors } from '../../../config/colors';
+import { normalizeTextValue } from '../../../helpers';
 import type { Props } from './propsType';
 
 interface styledProps {
@@ -101,10 +102,7 @@ export default function TextAreaInputNew({
           if (!textValue) {
             setShowPlaceholder(true);
           } else {
-            const trimmedAndSingleSpacedValue = textValue
-              .split('\n')
-              .map((line: any) => line.replace(/\s+/g, ' ').trim())
-              .join('\n');
+            const trimmedAndSingleSpacedValue = normalizeTextValue(textValue);
             setTextValue(trimmedAndSingleSpacedValue);
             handleChange(trimmedAndSingleSpacedValue);
           }

--- a/src/components/form/inputs/TextAreaInputNew.tsx
+++ b/src/components/form/inputs/TextAreaInputNew.tsx
@@ -100,10 +100,17 @@ export default function TextAreaInputNew({
           }
           if (!textValue) {
             setShowPlaceholder(true);
+          } else {
+            const trimmedAndSingleSpacedValue = textValue
+              .split('\n')
+              .map((line: any) => line.replace(/\s+/g, ' ').trim())
+              .join('\n');
+            setTextValue(trimmedAndSingleSpacedValue);
+            handleChange(trimmedAndSingleSpacedValue);
           }
         }}
         onChange={(e: any) => {
-          const newVal = e.target.value;
+          const newVal = e.target.value.trimStart();
           if (name === 'description') {
             if (newVal.length <= 120) {
               handleChange(newVal);

--- a/src/components/form/inputs/TextInputNew2.tsx
+++ b/src/components/form/inputs/TextInputNew2.tsx
@@ -64,6 +64,10 @@ export default function TextInputNew({
     }
   }, [textValue]);
 
+  const normalizeInput = (input: string) => {
+    return input.replace(/\s+/g, ' ').trim();
+  };
+
   return (
     <InputOuterBox
       color={color}
@@ -84,11 +88,11 @@ export default function TextInputNew({
         }}
         data-testid={testId}
         onChange={(e: any) => {
-          const newVal = e.target.value;
+          const newVal = e.target.value.trimStart();
           if (name === 'name') {
             if (newVal.length <= 20) {
-              handleChange(newVal);
-              setTextValue(newVal);
+              handleChange(normalizeInput(newVal));
+              setTextValue(normalizeInput(newVal));
               setCharacterError(false);
               setColor && setColor(false, name);
             } else {
@@ -96,7 +100,7 @@ export default function TextInputNew({
               setColor && setColor(true, name);
             }
           } else {
-            handleChange(newVal);
+            handleChange(normalizeInput(newVal));
             setTextValue(newVal);
           }
         }}

--- a/src/components/form/inputs/TextInputNew2.tsx
+++ b/src/components/form/inputs/TextInputNew2.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { colors } from '../../../config/colors';
+import { normalizeInput } from '../../../helpers';
 import type { Props } from './propsType';
 
 interface styledProps {
@@ -63,10 +64,6 @@ export default function TextInputNew({
       setIsError(false);
     }
   }, [textValue]);
-
-  const normalizeInput = (input: string) => {
-    return input.replace(/\s+/g, ' ').trim();
-  };
 
   return (
     <InputOuterBox

--- a/src/helpers/__test__/helpers.spec.ts
+++ b/src/helpers/__test__/helpers.spec.ts
@@ -19,7 +19,9 @@ import {
   formatSat,
   filterCount,
   userCanManageBounty,
-  formatPercentage
+  formatPercentage,
+  normalizeInput,
+  normalizeTextValue
 } from '../helpers-extended';
 
 beforeAll(() => {
@@ -404,6 +406,46 @@ describe('testing helpers', () => {
     it('should display "0" for non-numeric inputs', () => {
       expect(formatPercentage(undefined)).toBe('0');
       expect(formatPercentage(null as any)).toBe('0');
+    });
+  });
+
+  describe('normalizeInput function', () => {
+    test('should trim spaces only without removing inner spaces', () => {
+      const input = '  Hello World  ';
+      const expected = 'Hello World';
+      expect(normalizeInput(input)).toBe(expected);
+    });
+
+    test('should replace multiple spaces with a single space', () => {
+      const input = 'Hello    World';
+      const expected = 'Hello World';
+      expect(normalizeInput(input)).toBe(expected);
+    });
+
+    test('should return empty string if input is only spaces', () => {
+      const input = '     ';
+      const expected = '';
+      expect(normalizeInput(input)).toBe(expected);
+    });
+  });
+
+  describe('normalizeTextValue function', () => {
+    test('should trim spaces and maintain line breaks', () => {
+      const textValue = '  Hello \n World  \n\n Test  ';
+      const expected = 'Hello\nWorld\n\nTest';
+      expect(normalizeTextValue(textValue)).toBe(expected);
+    });
+
+    test('should replace multiple spaces with a single space and maintain line breaks', () => {
+      const textValue = 'Hello       World\nThis         is          a         test';
+      const expected = 'Hello World\nThis is a test';
+      expect(normalizeTextValue(textValue)).toBe(expected);
+    });
+
+    test('should return empty string if input is only spaces or line breaks', () => {
+      const textValue = '   \n  \n ';
+      const expected = '';
+      expect(normalizeTextValue(textValue)).toBe(expected);
     });
   });
 });

--- a/src/helpers/helpers-extended.ts
+++ b/src/helpers/helpers-extended.ts
@@ -383,3 +383,18 @@ export const formatPercentage = (value?: number): string => {
   }
   return '0';
 };
+
+export const normalizeInput = (input: string) => {
+  return input.replace(/\s+/g, ' ').trim();
+};
+
+export const normalizeTextValue = (textValue: string): string => {
+  const processedLines = textValue.split('\n').map((line) => line.replace(/\s+/g, ' ').trim());
+
+  // Check if all processed lines are empty
+  if (processedLines.every((line) => line === '')) {
+    return '';
+  }
+
+  return processedLines.join('\n');
+};


### PR DESCRIPTION
### Problem:
The platform currently allows the creation of bounties with titles, descriptions, and acceptance criteria containing only spaces. This behavior results in bounties that may seem empty or improperly formatted, leading to potential confusion and a lack of clarity in bounty requirements.

### Expected Behavior:
The creation process should be enhanced to ensure:
- Spaces by themselves are not accepted in bounty titles, descriptions, or acceptance criteria.
- Unnecessary spaces at the beginning and end of these fields are trimmed.
- The `Next` button is enabled only when the bounty title is validly filled, excluding fields with just spaces.

## Issue ticket number and link:
- **Ticket Number:** [ 266 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/266 ]

### Solution:
Implemented input handling improvements in the form components to ensure that leading spaces are trimmed upon input, and spaces alone are not considered valid inputs. For the acceptance criteria, the input is now processed to remove extra spaces between words and trimmed on blur to ensure the data is formatted correctly before submission.

### Changes:
`TextAreaInput.tsx (Description):` Modified onChange to use `trimStart()` for the input value.
`TextInputNew2.tsx (Title):` Adjusted to trim the start of the new value on change.
`TextAreaInputNew.tsx (Deliverables):` Enhanced onBlur and onChange handlers to trim start and normalize spaces within input values, ensuring a single space between words and trimming input both at the start and in between lines.

### Evidence:
 Please see the attached video as evidence.
 https://www.loom.com/share/7188070257264a7d8914ff55f7b01492

### Testing:
**Browser Compatibility:**
- Extensively tested on Chrome to ensure the fixes work as expected and the behavior is consistent across various test cases.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested on Chrome
- [x] I have created a unit test.
- [x] I have provided a recording