### PR TITLE
Change component test description to accurately reflect sign in test

### DIFF
--- a/src/people/main/__tests__/Header.spec.tsx
+++ b/src/people/main/__tests__/Header.spec.tsx
@@ -76,7 +76,7 @@ describe('AboutView Component', () => {
     });
   });
 
-  it('should render get sphinx button', async () => {
+  it('should render sign in button', async () => {
     jest.spyOn(mainStore, 'getIsAdmin').mockReturnValue(Promise.resolve(false));
     jest.spyOn(mainStore, 'getPersonById').mockReturnValue(Promise.resolve(person));
     jest.spyOn(mainStore, 'getSelf').mockReturnValue(Promise.resolve());


### PR DESCRIPTION
## Describe your changes
There was a component test for rendering the sign-in button in the header. However the description was "get sphinx" in stead of "Sign in". I've changed the name get sphinx -> sign in so the test description is less confusing
