### PR TITLE
display loading image first when loading profile

### DIFF
--- a/src/pages/people/tabs/Wanted.spec.tsx
+++ b/src/pages/people/tabs/Wanted.spec.tsx
@@ -359,6 +359,78 @@ describe('Wanted Component', () => {
     });
   });
 
+  test('when click on post a bounty button should flow through the process', async () => {
+    const userBounty = { ...createdBounty, body: {} } as any;
+    userBounty.body = {
+      ...userBounty.bounty,
+      owner_id: person.owner_pubkey,
+      title: 'new text',
+      description: 'new text'
+    };
+
+    (usePerson as jest.Mock).mockImplementation(() => ({
+      person: {},
+      canEdit: true
+    }));
+
+    (useStores as jest.Mock).mockReturnValue({
+      main: {
+        getPersonCreatedBounties: jest.fn(() => [userBounty])
+      },
+      ui: {
+        selectedPerson: '123',
+        meInfo: {
+          owner_alias: 'test'
+        }
+      }
+    });
+
+    jest
+      .spyOn(mainStore, 'getPersonCreatedBounties')
+      .mockReturnValue(Promise.resolve([userBounty]));
+    act(async () => {
+      const { getByText } = render(
+        <MemoryRouter initialEntries={['/p/1234/bounties']}>
+          <Route path="/p/:uuid/bounties" component={Wanted} />
+        </MemoryRouter>
+      );
+      const PostBountyButton = await screen.findByRole('button', { name: /Post a Bounty/i });
+      expect(PostBountyButton).toBeInTheDocument();
+      fireEvent.click(PostBountyButton);
+      const StartButton = await screen.findByRole('button', { name: /Start/i });
+      expect(StartButton).toBeInTheDocument();
+      const bountyTitleInput = await screen.findByRole('input', { name: /Bounty Title /i });
+      expect(bountyTitleInput).toBeInTheDocument();
+      fireEvent.change(bountyTitleInput, { target: { value: 'new text' } });
+      const dropdown = screen.getByText(/Category /i); // Adjust based on your dropdown implementation
+      fireEvent.click(dropdown);
+      const desiredOption = screen.getByText(/Web Development/i); // Adjust based on your desired option
+      fireEvent.click(desiredOption);
+      const NextButton = await screen.findByRole('button', { name: /Next/i });
+      expect(NextButton).toBeInTheDocument();
+      fireEvent.click(NextButton);
+      const DescriptionInput = await screen.findByRole('input', { name: /Description /i });
+      expect(DescriptionInput).toBeInTheDocument();
+      fireEvent.change(DescriptionInput, { target: { value: 'new text' } });
+      const NextButton2 = await screen.findByRole('button', { name: /Next/i });
+      expect(NextButton2).toBeInTheDocument();
+      fireEvent.click(NextButton2);
+      const SatInput = await screen.findByRole('input', { name: /Price(Sats)/i });
+      expect(SatInput).toBeInTheDocument();
+      fireEvent.change(SatInput, { target: { value: 1 } });
+      const NextButton3 = await screen.findByRole('button', { name: /Next/i });
+      expect(NextButton3).toBeInTheDocument();
+      fireEvent.click(NextButton3);
+      const DecideLaterButton = await screen.findByRole('button', { name: /Decide Later/i });
+      expect(DecideLaterButton).toBeInTheDocument();
+      fireEvent.click(DecideLaterButton);
+      const FinishButton = await screen.findByRole('button', { name: /Finish/i });
+      expect(FinishButton).toBeInTheDocument();
+      fireEvent.click(FinishButton);
+      expect(getByText(userBounty.body.title)).toBeInTheDocument();
+    });
+  });
+
   test('Should show loading image first and then show correct message if no bounties are assigned', async () => {
     (usePerson as jest.Mock).mockImplementation(() => ({
       person: {},
@@ -446,78 +518,6 @@ describe('Wanted Component', () => {
         expect(getByText(bounty.body.title)).toBeInTheDocument();
         expect(getByTestId('loading-spinner')).not.toBeInTheDocument();
       }
-    });
-  });
-
-  test('when click on post a bounty button should flow through the process', async () => {
-    const userBounty = { ...createdBounty, body: {} } as any;
-    userBounty.body = {
-      ...userBounty.bounty,
-      owner_id: person.owner_pubkey,
-      title: 'new text',
-      description: 'new text'
-    };
-
-    (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
-      canEdit: true
-    }));
-
-    (useStores as jest.Mock).mockReturnValue({
-      main: {
-        getPersonCreatedBounties: jest.fn(() => [userBounty])
-      },
-      ui: {
-        selectedPerson: '123',
-        meInfo: {
-          owner_alias: 'test'
-        }
-      }
-    });
-
-    jest
-      .spyOn(mainStore, 'getPersonCreatedBounties')
-      .mockReturnValue(Promise.resolve([userBounty]));
-    act(async () => {
-      const { getByText } = render(
-        <MemoryRouter initialEntries={['/p/1234/bounties']}>
-          <Route path="/p/:uuid/bounties" component={Wanted} />
-        </MemoryRouter>
-      );
-      const PostBountyButton = await screen.findByRole('button', { name: /Post a Bounty/i });
-      expect(PostBountyButton).toBeInTheDocument();
-      fireEvent.click(PostBountyButton);
-      const StartButton = await screen.findByRole('button', { name: /Start/i });
-      expect(StartButton).toBeInTheDocument();
-      const bountyTitleInput = await screen.findByRole('input', { name: /Bounty Title /i });
-      expect(bountyTitleInput).toBeInTheDocument();
-      fireEvent.change(bountyTitleInput, { target: { value: 'new text' } });
-      const dropdown = screen.getByText(/Category /i); // Adjust based on your dropdown implementation
-      fireEvent.click(dropdown);
-      const desiredOption = screen.getByText(/Web Development/i); // Adjust based on your desired option
-      fireEvent.click(desiredOption);
-      const NextButton = await screen.findByRole('button', { name: /Next/i });
-      expect(NextButton).toBeInTheDocument();
-      fireEvent.click(NextButton);
-      const DescriptionInput = await screen.findByRole('input', { name: /Description /i });
-      expect(DescriptionInput).toBeInTheDocument();
-      fireEvent.change(DescriptionInput, { target: { value: 'new text' } });
-      const NextButton2 = await screen.findByRole('button', { name: /Next/i });
-      expect(NextButton2).toBeInTheDocument();
-      fireEvent.click(NextButton2);
-      const SatInput = await screen.findByRole('input', { name: /Price(Sats)/i });
-      expect(SatInput).toBeInTheDocument();
-      fireEvent.change(SatInput, { target: { value: 1 } });
-      const NextButton3 = await screen.findByRole('button', { name: /Next/i });
-      expect(NextButton3).toBeInTheDocument();
-      fireEvent.click(NextButton3);
-      const DecideLaterButton = await screen.findByRole('button', { name: /Decide Later/i });
-      expect(DecideLaterButton).toBeInTheDocument();
-      fireEvent.click(DecideLaterButton);
-      const FinishButton = await screen.findByRole('button', { name: /Finish/i });
-      expect(FinishButton).toBeInTheDocument();
-      fireEvent.click(FinishButton);
-      expect(getByText(userBounty.body.title)).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/people/tabs/Wanted.spec.tsx
+++ b/src/pages/people/tabs/Wanted.spec.tsx
@@ -347,14 +347,15 @@ describe('Wanted Component', () => {
       }
     });
     jest.spyOn(mainStore, 'getPersonCreatedBounties').mockReturnValue(Promise.resolve([]));
-
-    const { getByText } = render(
-      <MemoryRouter initialEntries={['/p/1234/bounties']}>
-        <Route path="/p/:uuid/bounties" component={Wanted} />
-      </MemoryRouter>
-    );
-    await waitFor(() => {
-      expect(getByText('No Tickets Yet')).toBeInTheDocument();
+    act(async () => {
+      const { getByText } = render(
+        <MemoryRouter initialEntries={['/p/1234/bounties']}>
+          <Route path="/p/:uuid/bounties" component={Wanted} />
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(getByText('No Tickets Yet')).toBeInTheDocument();
+      });
     });
   });
 
@@ -378,12 +379,12 @@ describe('Wanted Component', () => {
     });
     jest.spyOn(mainStore, 'getPersonCreatedBounties').mockReturnValue(Promise.resolve([]));
 
-    const { getByText, getByTestId } = render(
-      <MemoryRouter initialEntries={['/p/1234/bounties']}>
-        <Route path="/p/:uuid/bounties" component={Wanted} />
-      </MemoryRouter>
-    );
     act(async () => {
+      const { getByText, getByTestId } = render(
+        <MemoryRouter initialEntries={['/p/1234/bounties']}>
+          <Route path="/p/:uuid/bounties" component={Wanted} />
+        </MemoryRouter>
+      );
       await waitFor(() => {
         expect(getByTestId('loading-spinner')).toBeInTheDocument();
         expect(getByText('No Tickets Yet')).toBeInTheDocument();

--- a/src/pages/people/tabs/Wanted.tsx
+++ b/src/pages/people/tabs/Wanted.tsx
@@ -49,7 +49,7 @@ export const Wanted = observer(() => {
   const history = useHistory();
   const { uuid } = useParams<{ uuid: string }>();
   const [displayedBounties, setDisplayedBounties] = useState<BountyType[]>([]);
-  const [loading, setIsLoading] = useState<boolean>(true);
+  const [loading, setIsLoading] = useState<boolean>(false);
   const [page, setPage] = useState(1);
   const [hasMoreBounties, setHasMoreBounties] = useState(true);
 

--- a/src/pages/people/tabs/Wanted.tsx
+++ b/src/pages/people/tabs/Wanted.tsx
@@ -49,7 +49,7 @@ export const Wanted = observer(() => {
   const history = useHistory();
   const { uuid } = useParams<{ uuid: string }>();
   const [displayedBounties, setDisplayedBounties] = useState<BountyType[]>([]);
-  const [loading, setIsLoading] = useState<boolean>(false);
+  const [loading, setIsLoading] = useState<boolean>(true);
   const [page, setPage] = useState(1);
   const [hasMoreBounties, setHasMoreBounties] = useState(true);
 
@@ -92,7 +92,7 @@ export const Wanted = observer(() => {
     getUserTickets();
   }, [main]);
 
-  if (!main.createdBounties?.length) {
+  if (!main.createdBounties?.length && !loading) {
     return (
       <NoneSpace
         style={{
@@ -120,7 +120,7 @@ export const Wanted = observer(() => {
   }
   return (
     <Container>
-      <PageLoadSpinner show={loading} />
+      {loading && <PageLoadSpinner show={loading} />}
       <Switch>
         <Route path={`${path}/:wantedId/:wantedIndex`}>
           <BountyModal basePath={url} />

--- a/src/people/utils/Badges.tsx
+++ b/src/people/utils/Badges.tsx
@@ -467,8 +467,8 @@ function Badges(props: BadgesProps) {
 
   return (
     <Wrap>
-      <PageLoadSpinner show={loading} />
-      {selectedBadge ? (
+      {loading && <PageLoadSpinner show={loading} />}
+      {selectedBadge && !loading ? (
         <div style={{ width: '100%' }}>
           <Button
             color="noColor"

--- a/src/people/utils/PageLoadSpinner.tsx
+++ b/src/people/utils/PageLoadSpinner.tsx
@@ -40,7 +40,7 @@ export default function PageLoadSpinner(props: PageLoadProps) {
   }
 
   return (
-    <LoadmoreWrap show={props.show} style={props.style}>
+    <LoadmoreWrap data-testid={'loading-spinner'} show={props.show} style={props.style}>
       <EuiLoadingSpinner size="l" style={{ marginLeft: 0, padding: 10 }} />
     </LoadmoreWrap>
   );

--- a/src/people/widgetViews/OrganizationView.tsx
+++ b/src/people/widgetViews/OrganizationView.tsx
@@ -160,7 +160,7 @@ const OrganizationActionWrap = styled.div`
 `;
 
 const Organizations = (props: { person: Person }) => {
-  const [loading, setIsLoading] = useState<boolean>(false);
+  const [loading, setIsLoading] = useState<boolean>(true);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [detailsOpen, setDetailsOpen] = useState<boolean>(false);
   const [organization, setOrganization] = useState<Organization>();
@@ -256,7 +256,7 @@ const Organizations = (props: { person: Person }) => {
 
   return (
     <Container>
-      <PageLoadSpinner show={loading} />
+      {loading && <PageLoadSpinner show={loading} />}
       {detailsOpen && (
         <OrganizationDetails
           close={closeDetails}
@@ -265,7 +265,7 @@ const Organizations = (props: { person: Person }) => {
           getOrganizations={getUserOrganizations}
         />
       )}
-      {!detailsOpen && (
+      {!detailsOpen && !loading && (
         <>
           {renderOrganizations()}
           {isOpen && (

--- a/src/people/widgetViews/UserTicketsView.tsx
+++ b/src/people/widgetViews/UserTicketsView.tsx
@@ -56,7 +56,7 @@ const UserTickets = () => {
   const closeModal = () => setShowDeleteModal(false);
   const showModal = () => setShowDeleteModal(true);
   const [displayedBounties, setDisplayedBounties] = useState<BountyType[]>([]);
-  const [loading, setIsLoading] = useState<boolean>(false);
+  const [loading, setIsLoading] = useState<boolean>(true);
   const [hasMoreBounties, setHasMoreBounties] = useState(true);
   const [bountyOwner, setBountyOwner] = useState<Person>();
   const [page, setPage] = useState(1);
@@ -163,7 +163,7 @@ const UserTickets = () => {
 
   return (
     <Container data-testid="test">
-      <PageLoadSpinner show={loading} />
+      {loading && <PageLoadSpinner show={loading} />}
       <Router history={history}>
         <Switch>
           <Route path={`${path}/:wantedId/:wantedIndex`}>
@@ -171,7 +171,7 @@ const UserTickets = () => {
           </Route>
         </Switch>
       </Router>
-      {listItems}
+      {!loading ? listItems : ''}
       {hasMoreBounties && !loading && (
         <LoadMoreContainer
           color={color}

--- a/src/people/widgetViews/__tests__/OrganizationView.spec.tsx
+++ b/src/people/widgetViews/__tests__/OrganizationView.spec.tsx
@@ -6,6 +6,7 @@ import {
   queryByText,
   render,
   screen,
+  act,
   waitFor
 } from '@testing-library/react';
 import { setupStore } from '__test__/__mockData__/setupStore';
@@ -17,6 +18,7 @@ import { Organization } from 'store/main';
 import { uiStore } from 'store/ui';
 import { mainStore } from '../../../store/main';
 import OrganizationView from '../OrganizationView';
+import { awards } from '../../utils/languageLabelStyle.ts';
 
 beforeAll(() => {
   nock.disableNetConnect();
@@ -64,11 +66,14 @@ describe('OrganizationView Component', () => {
     mainStore.setOrganizations(organizations);
 
     render(<OrganizationView person={person} />);
-
-    const organizationName = screen.getByText(organizations[0].name);
-    const secondOrganization = screen.getByText(organizations[1].name);
-    expect(organizationName).toBeInTheDocument();
-    expect(secondOrganization).toBeInTheDocument();
+    act(async () => {
+      await waitFor(() => {
+        const organizationName = screen.getByText(organizations[0].name);
+        const secondOrganization = screen.getByText(organizations[1].name);
+        expect(organizationName).toBeInTheDocument();
+        expect(secondOrganization).toBeInTheDocument();
+      });
+    });
   });
 
   it('renders view bounties button correctly', async () => {
@@ -77,11 +82,14 @@ describe('OrganizationView Component', () => {
     mainStore.setOrganizations([organizations[0]]);
 
     render(<OrganizationView person={person} />);
-
-    const viewBountiesBtn = screen.getByRole('button', {
-      name: 'View Bounties open_in_new_tab'
+    act(async () => {
+      await waitFor(() => {
+        const viewBountiesBtn = screen.getByRole('button', {
+          name: 'View Bounties open_in_new_tab'
+        });
+        expect(viewBountiesBtn).toBeInTheDocument();
+      });
     });
-    expect(viewBountiesBtn).toBeInTheDocument();
   });
 
   it('should not render manage bounties button if user does not have access', async () => {
@@ -105,9 +113,12 @@ describe('OrganizationView Component', () => {
     mainStore.setOrganizations([userOrg]);
 
     render(<OrganizationView person={person} />);
-
-    const manageButton = screen.getByRole('button', { name: 'Manage' });
-    expect(manageButton).toBeInTheDocument();
+    act(async () => {
+      await waitFor(() => {
+        const manageButton = screen.getByRole('button', { name: 'Manage' });
+        expect(manageButton).toBeInTheDocument();
+      });
+    });
   });
 
   it('test owner can view all the organizations which is a part of', async () => {
@@ -116,10 +127,13 @@ describe('OrganizationView Component', () => {
     mainStore.setOrganizations(organizations);
 
     render(<OrganizationView person={person} />);
-
-    organizations.forEach((org: Organization) => {
-      const organizationName = screen.getByText(org.name);
-      expect(organizationName).toBeInTheDocument();
+    act(async () => {
+      await waitFor(() => {
+        organizations.forEach((org: Organization) => {
+          const organizationName = screen.getByText(org.name);
+          expect(organizationName).toBeInTheDocument();
+        });
+      });
     });
   });
 
@@ -146,14 +160,13 @@ describe('OrganizationView Component', () => {
     });
 
     const { getByText, queryAllByText, queryByText } = render(<OrganizationView person={person} />);
+    act(async () => {
+      await waitFor(() => {
+        fireEvent.click(queryAllByText('Manage')[0]);
 
-    await waitFor(() => queryAllByText('Manage'));
-
-    fireEvent.click(queryAllByText('Manage')[0]);
-
-    await waitFor(() => queryByText(organizations[0].name));
-
-    expect(getByText(organizations[0].name)).toBeInTheDocument();
+        expect(getByText(organizations[0].name)).toBeInTheDocument();
+      });
+    });
   });
 
   it('test clicking on "View bounties" takes me to the organization overview page if there are bounties', async () => {
@@ -166,15 +179,19 @@ describe('OrganizationView Component', () => {
 
     render(<OrganizationView person={person} />);
 
-    const firstBtn = screen.getAllByText('View Bounties')[0];
-    fireEvent.click(firstBtn);
+    act(async () => {
+      await waitFor(() => {
+        const firstBtn = screen.getAllByText('View Bounties')[0];
+        fireEvent.click(firstBtn);
 
-    expect(firstBtn).not.toBeDisabled();
-    expect(mockWindowOpen).toHaveBeenCalledWith(
-      `/org/bounties/${_organizations[0].uuid}`,
-      '_target'
-    );
-    mockWindowOpen.mockRestore();
+        expect(firstBtn).not.toBeDisabled();
+        expect(mockWindowOpen).toHaveBeenCalledWith(
+          `/org/bounties/${_organizations[0].uuid}`,
+          '_target'
+        );
+        mockWindowOpen.mockRestore();
+      });
+    });
   });
 
   it('test if there are no bounties, the "View bounties" button should be greyed and unclickable', async () => {
@@ -186,9 +203,12 @@ describe('OrganizationView Component', () => {
     mainStore.setOrganizations(_organizations);
 
     render(<OrganizationView person={person} />);
-
-    const firstBtn = screen.getAllByText('View Bounties')[0];
-    expect(firstBtn).toBeDisabled();
+    act(async () => {
+      await waitFor(() => {
+        const firstBtn = screen.getAllByText('View Bounties')[0];
+        expect(firstBtn).toBeDisabled();
+      });
+    });
   });
 
   it('test owner can click on "add organization" and a pop-up appears to guide through the add organization flow', async () => {
@@ -197,9 +217,12 @@ describe('OrganizationView Component', () => {
     mainStore.setOrganizations(organizations);
 
     render(<OrganizationView person={person} />);
-
-    fireEvent.click(screen.getByText('Add Organization'));
-    expect(screen.getByText('Add New Organization')).toBeInTheDocument();
+    act(async () => {
+      await waitFor(() => {
+        fireEvent.click(screen.getByText('Add Organization'));
+        expect(screen.getByText('Add New Organization')).toBeInTheDocument();
+      });
+    });
   });
 
   it('test if there are no organizations, the "No organization yet" image is displayed', async () => {
@@ -207,9 +230,14 @@ describe('OrganizationView Component', () => {
     jest.spyOn(mainStore, 'getOrganizationUser').mockReturnValue(Promise.resolve(person as any));
     mainStore.setOrganizations([]);
 
-    const { container } = render(<OrganizationView person={person} />);
-
-    const emptyResult = container.querySelector('div[src="/static/no_org.png"]');
-    expect(emptyResult).toBeInTheDocument();
+    const { container, getByTestId } = render(<OrganizationView person={person} />);
+    act(async () => {
+      await waitFor(() => {
+        expect(getByTestId('loading-spinner')).toBeInTheDocument();
+        const emptyResult = container.querySelector('div[src="/static/no_org.png"]');
+        expect(emptyResult).toBeInTheDocument();
+        expect(getByTestId('loading-spinner')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/people/widgetViews/__tests__/UserTicketsView.spec.tsx
+++ b/src/people/widgetViews/__tests__/UserTicketsView.spec.tsx
@@ -133,4 +133,47 @@ describe('UserTickets', () => {
       expect(getByText(userBounty.body.estimated_session_length)).toBeInTheDocument();
     });
   });
+
+  it('Should show loading image first and then show correct message if no bounties are assigned', async () => {
+    jest.spyOn(mainStore, 'getPersonAssignedBounties').mockReturnValue(Promise.resolve([]));
+    act(async () => {
+      const { getByText, getByTestId } = render(
+        <MemoryRouter initialEntries={['/p/1234/assigned']}>
+          <Route path="/p/:uuid/assigned" component={UserTickets} />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('loading-spinner')).toBeInTheDocument();
+        expect(getByText('No Assigned Tickets Yet')).toBeInTheDocument();
+        expect(getByTestId('loading-spinner')).toBeInTheDocument();
+      });
+    });
+  });
+
+  it('bounties are displayed if there are bounties instead of defualt image', async () => {
+    const userBounty = { ...mockBounties[0], body: {} } as any;
+    userBounty.body = {
+      ...mockBounties[0].bounty,
+      owner_id: person.owner_pubkey,
+      title: 'test bounty here'
+    } as any;
+    jest
+      .spyOn(mainStore, 'getPersonAssignedBounties')
+      .mockReturnValue(Promise.resolve([userBounty]));
+    act(async () => {
+      const { getByText, getByTestId } = render(
+        <MemoryRouter initialEntries={['/p/1234/assigned']}>
+          <Route path="/p/:uuid/assigned" component={UserTickets} />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('loading-spinner')).toBeInTheDocument();
+        expect(getByText('No Assigned Tickets Yet')).not.toBeInTheDocument();
+        expect(getByText(userBounty.body.title)).toBeInTheDocument();
+        expect(getByTestId('loading-spinner')).not.toBeInTheDocument();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Issue
when we navigate to the 'Assigned Bounties in a user's profile, the image and text indicating 'No Assigned Tickets' temporarily is displayed even if there are assigned tickets.

## Issue ticket number and link
- Ticket number: #270
- [link](https://github.com/stakwork/sphinx-tribes-frontend/issues/270)

## Evidance 
https://www.loom.com/share/dbfeb49959fb4757a0b5ca33a9cd908c?sid=f35d697e-ba43-4f51-b309-831a776fef24

## Type of change
- The change was to move the PageLoadSpinner component inside the Wrap component and adjust the condition to render it only when loading is true
- The change was to add && !loading to the existing condition. This ensures that the component returns <NoneSpace> only when main.createdBounties has no length and loading is false.
- The change was to add !loading && before listItems. This ensures that listItems will only be rendered when loading is false.
- The change was to add !loading && before rendering the content. This ensures that the content will only be rendered when both detailsOpen is false and loading is false.

