### PR TITLE
Fixed Correctly link profiles to users on the Leaderboard Page

### DIFF
--- a/src/pages/leaderboard/__tests__/leaderboard.spec.tsx
+++ b/src/pages/leaderboard/__tests__/leaderboard.spec.tsx
@@ -177,7 +177,24 @@ describe('Leaderboard Component', () => {
         const userClipIcon = getByTestId('user-id');
         fireEvent.click(userClipIcon);
 
-        expect(userClipIcon.getAttribute('href')).toEqual(`/p/${person[0].owner_pubkey}`);
+        expect(userClipIcon.getAttribute('href')).toEqual(`/p/${person[0].uuid}`);
+      });
+    });
+  });
+
+  test('clicking on the right profile is mapped to the right name displayed', () => {
+    act(async () => {
+      const { getByTestId } = render(<LeaderboardPage />);
+      await waitFor(async () => {
+        const userClipIcon = getByTestId('user-id');
+        fireEvent.click(userClipIcon);
+
+        await waitFor(() => {
+          expect(screen.getByText('owner_alias1').closest('a')).toHaveAttribute(
+            'href',
+            `/p/${person[0].uuid}`
+          );
+        });
       });
     });
   });

--- a/src/pages/leaderboard/top3/index.tsx
+++ b/src/pages/leaderboard/top3/index.tsx
@@ -70,7 +70,7 @@ const Item = ({ owner_pubkey, total_sats_earned, place }: ItemProps) => {
       <div>
         <EuiText textAlign="center" className="name">
           {!!person?.owner_alias && (
-            <Link className="name" to={`/p/${person.owner_pubkey}`}>
+            <Link className="name" to={`/p/${person.uuid}`}>
               {person.owner_alias}
               <MaterialIcon className="icon" icon="link" />
             </Link>

--- a/src/pages/leaderboard/userInfo/index.tsx
+++ b/src/pages/leaderboard/userInfo/index.tsx
@@ -61,7 +61,7 @@ export const UserInfo = observer(({ id }: { id: string }) => {
       />
       <div className="info">
         <EuiText className="name">
-          <Link data-testId={'user-id'} className="name" to={`/p/${person.owner_pubkey}`}>
+          <Link data-testId={'user-id'} className="name" to={`/p/${person.uuid}`}>
             {person.owner_alias}
             <MaterialIcon className="icon" icon="link" />
           </Link>


### PR DESCRIPTION
### Expected Behavior:
When a user navigates to the leaderboard page and selects a person, the system should accurately route them to the detailed profile or information page of the selected person, ensuring that the user views the correct individual's data and achievements as intended.

## Issue ticket number and link:
- **Ticket Number:** [ 279 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/279 ]

### Evidence:
 Please see the attached video as evidence.
https://www.loom.com/share/fbea8fb97b6d4a69b6b10cdc30955f2f

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested on Chrome
- [x] I have created a unit test.
- [x] I have provided a recording