### PR TITLE
Fixed add dynamic bounty count to org homepage

### DIFF
--- a/src/pages/tickets/org/OrgTickets.tsx
+++ b/src/pages/tickets/org/OrgTickets.tsx
@@ -192,6 +192,7 @@ function OrgBodyComponent() {
           languageString={languageString}
           organizationData={organizationData as Organization}
           org_uuid={uuid}
+          totalBountyCount={OrgTotalBounties}
         />
         <>
           <div

--- a/src/pages/tickets/org/orgHeader/index.tsx
+++ b/src/pages/tickets/org/orgHeader/index.tsx
@@ -71,7 +71,8 @@ export const OrgHeader = ({
   checkboxIdToSelectedMap,
   org_uuid,
   languageString,
-  organizationData
+  organizationData,
+  totalBountyCount
 }: OrgBountyHeaderProps) => {
   const { main, ui } = useStores();
   const [isPostBountyModalOpen, setIsPostBountyModalOpen] = useState(false);
@@ -421,7 +422,7 @@ export const OrgHeader = ({
       <NumberOfBounties>
         <BountyNumber>
           <Img src={file} alt="" />
-          <PrimaryText>284</PrimaryText>
+          <PrimaryText>{totalBountyCount}</PrimaryText>
           <SecondaryText>Bounties</SecondaryText>
         </BountyNumber>
       </NumberOfBounties>

--- a/src/people/interfaces.ts
+++ b/src/people/interfaces.ts
@@ -437,6 +437,7 @@ export interface OrgBountyHeaderProps {
   org_uuid?: string;
   organizationData: Organization;
   direction?: string;
+  totalBountyCount: number;
 }
 export interface PeopleHeaderProps {
   onChangeLanguage: (lang: CodingLanguage) => void;

--- a/src/people/widgetViews/__tests__/OrgHeader.spec.tsx
+++ b/src/people/widgetViews/__tests__/OrgHeader.spec.tsx
@@ -290,15 +290,13 @@ describe('OrgHeader Component', () => {
 
   it('displays the correct number of bounties based on the status filter', async () => {
     act(async () => {
-      // eslint-disable-next-line @typescript-eslint/typedef
-      // @ts-ignore
       jest
         .spyOn(mainStore, 'getSpecificOrganizationBounties')
         .mockImplementation((filters: any) => {
-          if (filters.Open) {
-            return Promise.resolve({ data: { total: 3, bounties: [] } });
+          if (filters && filters.Open) {
+            return Promise.resolve(Array(3).fill({}));
           }
-          return Promise.resolve({ data: { total: 8, bounties: [] } });
+          return Promise.resolve(Array(8).fill({}));
         });
 
       render(<OrgHeader {...MockProps} />);


### PR DESCRIPTION
### Expected Behavior:
The # should dynamically changed based on the # of bounties displayed

## Issue ticket number and link:
- **Ticket Number:** [ 248 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/248 ]

### Evidence:
 Please see the attached video as evidence.
https://www.loom.com/share/ea0b88aae7ac42e0be928c759370314b

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested on Chrome
- [x] I have created a unit test.
- [x] I have provided a recording