### PR TITLE
Fixed(org-fields): Organization Creation Extra Whitespace

### DIFF
--- a/src/helpers/__test__/helpers.spec.ts
+++ b/src/helpers/__test__/helpers.spec.ts
@@ -21,7 +21,8 @@ import {
   userCanManageBounty,
   formatPercentage,
   normalizeInput,
-  normalizeTextValue
+  normalizeTextValue,
+  normalizeUrl
 } from '../helpers-extended';
 
 beforeAll(() => {
@@ -446,6 +447,48 @@ describe('testing helpers', () => {
       const textValue = '   \n  \n ';
       const expected = '';
       expect(normalizeTextValue(textValue)).toBe(expected);
+    });
+  });
+
+  describe('normalizeUrl', () => {
+    it('removes all spaces from a URL and reconstructs it correctly', () => {
+      const inputsAndExpected: { input: string; expected: string }[] = [
+        {
+          input: 'https ://github.com/stakwork/sphinx-tribes-frontend/ issues/267',
+          expected: 'https://github.com/stakwork/sphinx-tribes-frontend/issues/267'
+        },
+        {
+          input: 'http s:// git hub.com /stak work/sphinx- tribes- frontend/issues / 267',
+          expected: 'https://github.com/stakwork/sphinx-tribes-frontend/issues/267'
+        },
+        {
+          input:
+            '          https  :/    /git              hub. com/ st                  akw  ork/sphinx-tri bes-fron tend/  issues     /2 67',
+          expected: 'https://github.com/stakwork/sphinx-tribes-frontend/issues/267'
+        },
+        {
+          input: 'https :// someotherurl.com /path/to /resource',
+          expected: 'https://someotherurl.com/path/to/resource'
+        },
+        {
+          input: 'https :// community.sphinx   .chat     /bounties',
+          expected: 'https://community.sphinx.chat/bounties'
+        },
+        {
+          input:
+            '      https:/   /community.    sphinx.c    hat/   org/boun     ties/ck95pe04nncj      naefo08g',
+          expected: 'https://community.sphinx.chat/org/bounties/ck95pe04nncjnaefo08g'
+        },
+        {
+          input:
+            'h          ttp         s:  //com      munity.sphinx.ch            at/p     /cd9dm5ua5fdts       j2c2mh0/organi   zations',
+          expected: 'https://community.sphinx.chat/p/cd9dm5ua5fdtsj2c2mh0/organizations'
+        }
+      ];
+
+      inputsAndExpected.forEach(({ input, expected }: { input: string; expected: string }) => {
+        expect(normalizeUrl(input)).toEqual(expected);
+      });
     });
   });
 });

--- a/src/helpers/helpers-extended.ts
+++ b/src/helpers/helpers-extended.ts
@@ -384,9 +384,7 @@ export const formatPercentage = (value?: number): string => {
   return '0';
 };
 
-export const normalizeInput = (input: string) => {
-  return input.replace(/\s+/g, ' ').trim();
-};
+export const normalizeInput = (input: string) => input.replace(/\s+/g, ' ').trim();
 
 export const normalizeTextValue = (textValue: string): string => {
   const processedLines = textValue.split('\n').map((line) => line.replace(/\s+/g, ' ').trim());
@@ -397,4 +395,14 @@ export const normalizeTextValue = (textValue: string): string => {
   }
 
   return processedLines.join('\n');
+};
+
+export const normalizeUrl = (input: string): string => {
+  const noSpaces = input.replace(/\s+/g, '');
+  const match = noSpaces.match(/(https?):\/\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\/(\d+)/);
+  if (match) {
+    return `${match[1]}://${match[2]}/${match[3]}/${match[4]}/${match[5]}/${match[6]}`;
+  } else {
+    return noSpaces;
+  }
 };

--- a/src/people/widgetViews/__tests__/AddOrganization.spec.tsx
+++ b/src/people/widgetViews/__tests__/AddOrganization.spec.tsx
@@ -5,9 +5,17 @@ import { mainStore } from 'store/main';
 import AddOrganization from '../organization/AddOrganization';
 const mockCloseHandler = jest.fn();
 const mockGetUserOrganizations = jest.fn();
+const mockAddToast = jest.fn();
 const mockOwnerPubKey = 'somePublicKey';
 
 describe('AddOrganization Component Tests', () => {
+  beforeEach(() => {
+    mockCloseHandler.mockReset();
+    mockGetUserOrganizations.mockReset();
+    mockAddToast.mockReset();
+    jest.clearAllMocks();
+  });
+
   test('Organization Name text field appears', () => {
     render(
       <AddOrganization
@@ -189,6 +197,33 @@ describe('AddOrganization Component Tests', () => {
         website: 'https://john.doe'
       });
       expect(mockGetUserOrganizations).toHaveBeenCalled();
+    });
+  });
+
+  test('Nothing happens if only spaces are entered in the Org Name', async () => {
+    jest
+      .spyOn(mainStore, 'addOrganization')
+      .mockImplementation(() => Promise.resolve({ status: 200 }));
+
+    render(
+      <AddOrganization
+        closeHandler={mockCloseHandler}
+        getUserOrganizations={mockGetUserOrganizations}
+        owner_pubkey={mockOwnerPubKey}
+      />
+    );
+
+    const orgNameInput = screen.getByPlaceholderText('My Organization...');
+    fireEvent.change(orgNameInput, { target: { value: '   ' } });
+
+    const addButton = screen.getByText('Add Organization');
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(mainStore.addOrganization).not.toHaveBeenCalled();
+      expect(mockCloseHandler).not.toHaveBeenCalled();
+      expect(mockGetUserOrganizations).not.toHaveBeenCalled();
+      expect(mockAddToast).not.toHaveBeenCalledWith('Organization created successfully', 'success');
     });
   });
 });

--- a/src/people/widgetViews/__tests__/AddUserModal.spec.tsx
+++ b/src/people/widgetViews/__tests__/AddUserModal.spec.tsx
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom';
-import '@testing-library/jest-dom/extend-expect';
 import nock from 'nock';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import AddUserModal from '../organization/AddUserModal';
 
 describe('AddUserModal Component', () => {
@@ -28,20 +28,21 @@ describe('AddUserModal Component', () => {
       .reply(200, [{ owner_pubkey: '...', owner_alias: 'Anish Yadav', img: '...' }]);
 
     const { getByPlaceholderText, getByText } = render(<AddUserModal {...mockProps} />);
-
-    (async () => {
-      const searchInput = getByPlaceholderText('Type to search ...');
-      fireEvent.change(searchInput, { target: { value: 'Anish' } });
-      await waitFor(() => expect(getByText('Anish Yadav')).toBeInTheDocument());
-      await waitFor(() => {
-        const addUserButton = getByText('Add User');
-        expect(addUserButton).toBeEnabled();
-        fireEvent.click(addUserButton);
-        expect(mockProps.onSubmit).toHaveBeenCalledTimes(1);
-        expect(mockProps.onSubmit).toHaveBeenCalledWith({
-          owner_pubkey: mockUser.owner_pubkey
+    act(() => {
+      (async () => {
+        const searchInput = getByPlaceholderText('Type to search ...');
+        fireEvent.change(searchInput, { target: { value: 'Anish' } });
+        await waitFor(() => expect(getByText('Anish Yadav')).toBeInTheDocument());
+        await waitFor(() => {
+          const addUserButton = getByText('Add User');
+          expect(addUserButton).toBeEnabled();
+          fireEvent.click(addUserButton);
+          expect(mockProps.onSubmit).toHaveBeenCalledTimes(1);
+          expect(mockProps.onSubmit).toHaveBeenCalledWith({
+            owner_pubkey: mockUser.owner_pubkey
+          });
         });
-      });
-    })();
+      })();
+    });
   });
 });

--- a/src/people/widgetViews/__tests__/AddUserModal.spec.tsx
+++ b/src/people/widgetViews/__tests__/AddUserModal.spec.tsx
@@ -4,6 +4,7 @@ import { render, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import AddUserModal from '../organization/AddUserModal';
+import { user } from '../../../__test__/__mockData__/user.ts';
 
 describe('AddUserModal Component', () => {
   it('filters people according to the search term, enables "Add User" Button and adds user when "Add User" button is clicked', async () => {
@@ -22,9 +23,8 @@ describe('AddUserModal Component', () => {
       img: ''
     };
 
-    nock('https://community.sphinx.chat')
-      .get('/people/search')
-      .query({ search: 'Anish', sortBy: 'owner_alias', limit: '4' })
+    nock(user.url)
+      .get('/people/search?search=anish&sortBy=owner_alias&limit=4')
       .reply(200, [{ owner_pubkey: '...', owner_alias: 'Anish Yadav', img: '...' }]);
 
     const { getByPlaceholderText, getByText } = render(<AddUserModal {...mockProps} />);

--- a/src/people/widgetViews/__tests__/EditOrgModal.spec.tsx
+++ b/src/people/widgetViews/__tests__/EditOrgModal.spec.tsx
@@ -140,4 +140,19 @@ describe('EditOrgModal Component', () => {
 
     expect(updatedDescriptionLength).toBe(initialDescriptionLength);
   });
+
+  test('Nothing happens if only spaces are entered in the Org Name', async () => {
+    render(<EditOrgModal {...props} />);
+
+    const orgNameInput = screen.getByLabelText(/Organization Name/i) as HTMLInputElement;
+    fireEvent.change(orgNameInput, { target: { value: '   ' } });
+
+    const saveChangesButton = screen.getByText('Save changes');
+    fireEvent.click(saveChangesButton);
+
+    await waitFor(() => {
+      expect(mockUpdateOrganization).not.toHaveBeenCalled();
+      expect(mockAddToast).not.toHaveBeenCalledWith('Successfully updated organization', 'success');
+    });
+  });
 });

--- a/src/people/widgetViews/organization/AddOrganization.tsx
+++ b/src/people/widgetViews/organization/AddOrganization.tsx
@@ -2,6 +2,7 @@ import React, { useState, DragEvent, ChangeEvent } from 'react';
 import styled from 'styled-components';
 import { useStores } from 'store';
 import { EuiGlobalToastList, EuiLoadingSpinner } from '@elastic/eui';
+import { normalizeInput, normalizeTextValue } from '../../../helpers';
 import { Toast } from './interface';
 import {
   ImgDashContainer,
@@ -235,13 +236,20 @@ const AddOrganization = (props: {
           img_url = await file.json();
         }
       }
+
+      if (!orgName.trim()) {
+        addErrorToast('Organization name is required');
+        setIsLoading(false);
+        return;
+      }
+
       const body = {
         owner_pubkey: props.owner_pubkey || '',
-        name: orgName,
-        description: description,
+        name: normalizeInput(orgName),
+        description: normalizeTextValue(description),
         img: img_url,
-        github: githubRepo,
-        website: websiteName
+        github: normalizeInput(githubRepo),
+        website: normalizeInput(websiteName)
       };
 
       const res = await main.addOrganization(body);

--- a/src/people/widgetViews/organization/EditOrgModal.tsx
+++ b/src/people/widgetViews/organization/EditOrgModal.tsx
@@ -373,7 +373,9 @@ const EditOrgModal = (props: EditOrgModalProps) => {
                 values,
                 setFieldValue,
                 errors,
-                initialValues
+                initialValues,
+                isValid,
+                dirty
               }: any) => (
                 <InputWrapper>
                   {schema.map((item: FormField) => (
@@ -432,7 +434,7 @@ const EditOrgModal = (props: EditOrgModalProps) => {
                     </InputContainer>
                   ))}
                   <Button
-                    disabled={nameColor || descColor ? true : false}
+                    disabled={!values.name || !isValid || !dirty}
                     onClick={() => handleSubmit()}
                     loading={loading}
                     style={{
@@ -445,7 +447,7 @@ const EditOrgModal = (props: EditOrgModalProps) => {
                       top: '390px',
                       left: '527px'
                     }}
-                    color={nameColor || descColor ? 'gray' : 'primary'}
+                    color={!values.name || !isValid || !dirty ? 'gray' : 'primary'}
                     text={'Save changes'}
                   />
                 </InputWrapper>


### PR DESCRIPTION
## Describe your changes
- An org can only be created if there is a text character in the name. In other words, an org name with only spaces shouldn't be created.

## Issue ticket number and link:

- **Ticket Number:** [ 267 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/267 ]

### Evidence:
 - Please see the attached video as evidence.
 https://www.loom.com/share/dfda281deb4e41dd866d3d938db3e04b

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested on Chrome
- [x] I have added unit tests for both tickets.
- [x] I have provided a recording.