### PR TITLE
[Org Homepage] Add hover effect on `"Skill"` button with color & cursor change

### DIFF
--- a/src/pages/tickets/org/orgHeader/OrgHeaderStyles.tsx
+++ b/src/pages/tickets/org/orgHeader/OrgHeaderStyles.tsx
@@ -53,7 +53,7 @@ export const FiltersRight = styled.span`
 `;
 
 export const SkillContainer = styled.span`
-  padding: 7px 0px;
+  padding: 6px 0px;
   align-items: center;
   display: flex;
   position: relative;
@@ -445,5 +445,35 @@ export const FilterCount = styled.div<styledProps>`
     align-items: center;
     text-align: center;
     color: ${(p: any) => p.color && p.color.pureWhite};
+  }
+`;
+
+export const SkillTextContainer = styled.div<styledProps>`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  .skillText {
+    font-family: 'Barlow';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 15px;
+    line-height: 17px;
+    letter-spacing: 0.15px;
+    display: flex;
+    align-items: center;
+    color: ${(p: any) => p.color && p.color.grayish.G200};
+  }
+  &:hover {
+    .skillText {
+      color: ${(p: any) => p.color && p.color.grayish.G50};
+    }
+  }
+  &:active {
+    .skillText {
+      color: ${(p: any) => p.color && p.color.grayish.G10};
+    }
   }
 `;

--- a/src/pages/tickets/org/orgHeader/index.tsx
+++ b/src/pages/tickets/org/orgHeader/index.tsx
@@ -25,7 +25,6 @@ import {
   EuiPopOverCheckbox,
   EuiPopOverCheckboxRight,
   FillContainer,
-  FilterLabel,
   Filters,
   FiltersRight,
   Header,
@@ -45,7 +44,8 @@ import {
   UrlButtonContainer,
   FilterCount,
   InnerContainer,
-  Formatter
+  Formatter,
+  SkillTextContainer
 } from './OrgHeaderStyles';
 
 const color = colors['light'];
@@ -310,7 +310,13 @@ export const OrgHeader = ({
               </EuiPopover>
             </NewStatusContainer>
             <SkillContainer>
-              <FilterLabel>Skill</FilterLabel>
+              <EuiPopover
+                button={
+                  <SkillTextContainer color={color}>
+                    <EuiText className="skillText">Skill</EuiText>
+                  </SkillTextContainer>
+                }
+              />
               {skillCountNumber > 0 && (
                 <FilterCount color={color}>
                   <EuiText className="filterCountText">{skillCountNumber}</EuiText>

--- a/src/people/widgetViews/__tests__/OrgHeader.spec.tsx
+++ b/src/people/widgetViews/__tests__/OrgHeader.spec.tsx
@@ -333,4 +333,18 @@ describe('OrgHeader Component', () => {
       });
     });
   });
+
+  test('shows hand icon on hover over the Skill text and toggles dropdown', () => {
+    render(<OrgHeader {...MockProps} />);
+    const skillText = screen.getByText('Skill');
+
+    expect(skillText).toBeInTheDocument();
+    expect(skillText).toHaveClass('skillText');
+
+    const dropdownButton = screen.getByTestId('skillDropdown');
+    fireEvent.click(dropdownButton);
+
+    const skillFilter = screen.getByTestId('skill-filter');
+    expect(skillFilter).toBeVisible();
+  });
 });


### PR DESCRIPTION
### Expected Behavior:
- Default text color of `Skill` button: grey.
- On hover: text turns black, cursor changes to hand icon.

## Issue ticket number and link:
- **Ticket Number:** [ 313 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/313 ]

### Evidence:
 Please see the attached video as evidence.
https://www.loom.com/share/e307fe8fdef240f0a042e871b400fb2c

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested on Chrome
- [x] I have created a unit test.
- [x] I have provided a recording