### PR TITLE
center the loading spinner on pages

### DIFF
--- a/src/pages/bots/Body.tsx
+++ b/src/pages/bots/Body.tsx
@@ -39,12 +39,12 @@ const BotText = styled.div`
 
 const Body = styled.div`
   flex: 1;
-  height: calc(100% - 105px);
-  padding-bottom: 80px;
+  height: calc(100vh - 60px);
   width: 100%;
   overflow: auto;
   display: flex;
   flex-direction: column;
+  align-items: center;
 `;
 const Label = styled.div`
   font-family: Roboto;

--- a/src/pages/tickets/style.ts
+++ b/src/pages/tickets/style.ts
@@ -2,11 +2,12 @@ import styled from 'styled-components';
 
 export const Body = styled.div`
   flex: 1;
-  height: calc(100% - 105px);
+  height: calc(100vh - 60px);
   width: 100%;
   overflow: auto;
   display: flex;
   flex-direction: column;
+  align-items: center;
 `;
 
 export const OrgBody = styled.div`

--- a/src/pages/tribes/Body.tsx
+++ b/src/pages/tribes/Body.tsx
@@ -22,7 +22,6 @@ import Tribe from './Tribe';
 const Body = styled.div`
   flex: 1;
   height: calc(100vh - 60px);
-  // padding-bottom:80px;
   width: 100%;
   overflow: auto;
   background: ${colors.dark.tribesBackground};
@@ -120,7 +119,7 @@ function BodyComponent() {
 
   if (loading) {
     return (
-      <Body style={{ justifyContent: 'center', alignItems: 'center' }}>
+      <Body data-testid="content" style={{ justifyContent: 'center', alignItems: 'center' }}>
         <EuiLoadingSpinner size="xl" />
       </Body>
     );

--- a/src/pages/tribes/__tests__/Body.spec.tsx
+++ b/src/pages/tribes/__tests__/Body.spec.tsx
@@ -143,4 +143,32 @@ describe('Tribes Body Component', () => {
       });
     });
   });
+
+  test('content element has justifyContent and alignItems centered', async () => {
+    (useStores as jest.Mock).mockReturnValue({
+      main: {
+        tribes: [],
+        getTribes: jest.fn()
+      },
+      ui: {
+        peoplePageNumber: 1,
+        searchText: 'abc',
+        tags: []
+      }
+    });
+
+    (useFuse as jest.Mock).mockReturnValue([]);
+
+    const { getByTestId } = render(<Body />);
+
+    const contentElement = getByTestId('content');
+
+    expect(contentElement).toBeInTheDocument();
+
+    const styles = window.getComputedStyle(contentElement);
+    const { justifyContent, alignItems } = styles;
+
+    expect(justifyContent).toEqual('center');
+    expect(alignItems).toEqual('center');
+  });
 });

--- a/src/people/main/Body.tsx
+++ b/src/people/main/Body.tsx
@@ -18,7 +18,7 @@ import { usePeopleFilteredSearch } from './usePeopleFilteredSearch';
 const color = colors['light'];
 const Body = styled.div<{ isMobile: boolean }>`
   flex: 1;
-  height: ${(p: any) => (p.isMobile ? 'calc(100% - 105px)' : 'calc(100% - 65px)')};
+  height: ${(p: any) => (p.isMobile ? 'calc(100% - 105px)' : 'calc(100vh - 60px)')};
   background: ${(p: any) => (p.isMobile ? undefined : color.grayish.G950)};
   width: 100%;
   overflow-x: hidden;
@@ -94,9 +94,20 @@ function BodyComponent() {
     history.push(`/p/${uuid}`);
   }
 
+  if (isLoading) {
+    return (
+      <Body
+        data-testid="content"
+        isMobile={isMobile}
+        style={{ justifyContent: 'center', alignItems: 'center' }}
+      >
+        <EuiLoadingSpinner size="xl" />
+      </Body>
+    );
+  }
+
   return (
     <Body
-      data-testid="content"
       isMobile={isMobile}
       onScroll={(e: any) => {
         handleScroll(e);
@@ -118,25 +129,21 @@ function BodyComponent() {
         />
       </div>
       <div className="content">
-        {isLoading ? (
-          <EuiLoadingSpinner className="loader" size="xl" />
-        ) : (
-          <>
-            {main.people.map((p: Person) => (
-              <PersonCard
-                {...p}
-                key={p.id}
-                small={isMobile}
-                squeeze={screenWidth < 1420}
-                selected={ui.selectedPerson === p.id}
-                select={selectPerson}
-              />
-            ))}
+        <>
+          {main.people.map((p: Person) => (
+            <PersonCard
+              {...p}
+              key={p.id}
+              small={isMobile}
+              squeeze={screenWidth < 1420}
+              selected={ui.selectedPerson === p.id}
+              select={selectPerson}
+            />
+          ))}
 
-            {!main.people.length && <NoResults />}
-            <PageLoadSpinner noAnimate show={loadingBottom} />
-          </>
-        )}
+          {!main.people.length && <NoResults />}
+          <PageLoadSpinner noAnimate show={loadingBottom} />
+        </>
       </div>
       {openStartUpModel && (
         <StartUpModal closeModal={closeModal} dataObject={'getWork'} buttonColor={'primary'} />

--- a/src/people/main/__tests__/Body.spec.tsx
+++ b/src/people/main/__tests__/Body.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import nock from 'nock';
 import { user } from '../../../__test__/__mockData__/user';
@@ -15,9 +15,9 @@ describe('BodyComponent', () => {
     .reply(200, {});
 
   it('content element has equal left and right margins', () => {
-    render(<BodyComponent />);
+    const { getByTestId } = render(<BodyComponent />);
 
-    const contentElement = screen.getByTestId('content');
+    const contentElement = getByTestId('content');
 
     expect(contentElement).toBeInTheDocument();
 
@@ -28,17 +28,34 @@ describe('BodyComponent', () => {
     expect(marginLeft).toEqual(marginRight);
   });
 
-  it('filter is in viewport when device is mobile', () => {
+  it('content element has justifyContent and alignItems centered', async () => {
+    const { getByTestId } = render(<BodyComponent />);
+
+    const contentElement = getByTestId('content');
+
+    expect(contentElement).toBeInTheDocument();
+
+    const styles = window.getComputedStyle(contentElement);
+    const { justifyContent, alignItems } = styles;
+
+    expect(justifyContent).toEqual('center');
+    expect(alignItems).toEqual('center');
+  });
+
+  it('filter is in viewport when device is mobile', async () => {
     Object.assign(window, { innerWidth: 375 });
+    act(async () => {
+      render(<BodyComponent />);
+      await waitFor(() => {
+        const filterNode = screen.getByTestId('PeopleHeader');
 
-    render(<BodyComponent />);
-    const filterNode = screen.getByTestId('PeopleHeader');
+        const { left, right, bottom, top, width, height } = filterNode.getBoundingClientRect();
 
-    const { left, right, bottom, top, width, height } = filterNode.getBoundingClientRect();
-
-    expect(left).toBeGreaterThanOrEqual(0);
-    expect(top).toBeGreaterThanOrEqual(0);
-    expect(right - width).toBeGreaterThanOrEqual(0);
-    expect(bottom - height).toBeGreaterThanOrEqual(0);
+        expect(left).toBeGreaterThanOrEqual(0);
+        expect(top).toBeGreaterThanOrEqual(0);
+        expect(right - width).toBeGreaterThanOrEqual(0);
+        expect(bottom - height).toBeGreaterThanOrEqual(0);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Loading spinner should be positioned in the center of the page.

## Issue ticket number and link
- Issue number #307
- [link](https://github.com/stakwork/sphinx-tribes-frontend/issues/307)

## Evidence 
https://www.loom.com/share/b1d7666f73a0487497a0bf16b544b247?sid=4e29e1bd-24cb-430b-b9cf-1c6a8ca8b2bc