### PR TITLE
Fix: Make "Sort by" button in Superadmin grey by default 

### DIFF
--- a/src/pages/superadmin/tableComponent/TableStyle.tsx
+++ b/src/pages/superadmin/tableComponent/TableStyle.tsx
@@ -255,7 +255,7 @@ export const DateFilterWrapper = styled.div<styledProps>`
     }
   }
   .filterText {
-    color: var(--Main-bottom-icons, var(--Hover-Icon-Color, #5f6368));
+    color: ${(p: any) => p.color && p.color.grayish.G200};
     font-family: Barlow;
     font-size: 15px;
     font-style: normal;

--- a/src/pages/superadmin/tableComponent/index.tsx
+++ b/src/pages/superadmin/tableComponent/index.tsx
@@ -347,7 +347,12 @@ export const MyTable = ({
                       Sort By:
                     </EuiText>
                     <div className="image">
-                      <EuiText className="filterText">
+                      <EuiText
+                        className="filterText"
+                        style={{
+                          color: isPopoverOpen ? color.grayish.G10 : ''
+                        }}
+                      >
                         {sortOrder === 'desc' ? 'Newest' : 'Oldest'}
                       </EuiText>
                       <MaterialIcon


### PR DESCRIPTION
## Describe your changes

fix "sort by" button ui style with default state and hover state

https://github.com/stakwork/sphinx-tribes-frontend/assets/23151576/9109c3df-ddb3-45cc-9228-a14a94465425


## Issue ticket number and link

closes #329 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have tested on a mobile device
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend