### PR TITLE
Fix: Consistent Default Photo Display for Users Without Photos Across Bounties

### DIFF
--- a/src/people/utils/NameTag.tsx
+++ b/src/people/utils/NameTag.tsx
@@ -74,12 +74,14 @@ const Wrap = styled.div<WrapProps>`
 function NameTag(props: NameTagProps) {
   const { owner_alias, owner_pubkey, img, created, id, style, widget, iconSize, textSize, isPaid } =
     props;
-  const { ui } = useStores();
+  const { ui, main } = useStores();
   const color = colors['light'];
 
   const history = useHistory();
 
   const isMobile = useIsMobile();
+
+  const userImg = img || main.getUserAvatarPlaceholder(owner_pubkey);
 
   const isSelected = ui.selectedPerson === id ? true : false;
 
@@ -113,7 +115,7 @@ function NameTag(props: NameTagProps) {
       >
         {!isSelected && (
           <>
-            <Img src={img || `/static/person_placeholder.png`} iconSize={iconSize} />
+            <Img src={userImg} iconSize={iconSize} data-testid="user-avatar" />
             <Name
               textSize={textSize}
               color={color.grayish.G250}
@@ -147,7 +149,7 @@ function NameTag(props: NameTagProps) {
           flexDirection: 'row'
         }}
       >
-        <Img src={img || `/static/person_placeholder.png`} iconSize={32} isPaid={isPaid} />
+        <Img src={userImg} iconSize={32} isPaid={isPaid} data-testid="user-avatar" />
         <div
           style={{
             display: 'flex',

--- a/src/people/utils/__test__/NameTag.spec.tsx
+++ b/src/people/utils/__test__/NameTag.spec.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as StoreHooks from '../../../store';
+import { useIsMobile } from '../../../hooks';
+import NameTag from '../NameTag.tsx';
+
+jest.mock('../../../store', () => ({
+  useStores: jest.fn()
+}));
+
+jest.mock('../../../hooks', () => ({
+  useIsMobile: jest.fn()
+}));
+
+describe('NameTag', () => {
+  const mockOwnerPubkey = 'test-pubkey';
+  const defaultImageUrl = '/static/avatarPlaceholders/placeholder_1.jpg';
+  const mockGetUserAvatarPlaceholder = jest.fn().mockReturnValue(defaultImageUrl);
+
+  beforeEach(() => {
+    (StoreHooks.useStores as jest.Mock).mockReturnValue({
+      main: {
+        getUserAvatarPlaceholder: mockGetUserAvatarPlaceholder
+      },
+      ui: {
+        selectedPerson: null
+      }
+    });
+    (useIsMobile as jest.Mock).mockReset();
+  });
+
+  it('displays the default face image on desktop side', () => {
+    (useIsMobile as jest.Mock).mockReturnValue(false);
+
+    render(
+      <NameTag owner_pubkey={mockOwnerPubkey} owner_alias={''} img={''} id={0} widget={undefined} />
+    );
+
+    expect(mockGetUserAvatarPlaceholder).toHaveBeenCalledWith(mockOwnerPubkey);
+    const imageElement = screen.getByTestId('user-avatar');
+    expect(imageElement).toBeInTheDocument();
+  });
+
+  it('displays the default face image on mobile side', () => {
+    (useIsMobile as jest.Mock).mockReturnValue(true);
+
+    render(
+      <NameTag owner_pubkey={mockOwnerPubkey} owner_alias={''} img={''} id={0} widget={undefined} />
+    );
+
+    expect(mockGetUserAvatarPlaceholder).toHaveBeenCalledWith(mockOwnerPubkey);
+    const imageElement = screen.getByTestId('user-avatar');
+    expect(imageElement).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Problem:
Inconsistency exists in displaying default user photos within bounties, specifically noted when entering the bounty details where a different stock image is shown instead of the default face picture used elsewhere.

### Expected Behavior:
A uniform default face picture should represent users without photos in both bounty listings and detailed views, ensuring consistency across desktop and mobile platforms.

## Issue ticket number and link:
- **Ticket Number:** [ 334 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/334 ]

### Evidence:
 Please see the attached video as evidence.
 https://www.loom.com/share/e0ba3e9bb1fa46f1b58c0f604615836d

### Testing:
**Browser Compatibility:**
- Extensively tested on Chrome to ensure the fixes work as expected and the behavior is consistent across various test cases.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested on Chrome
- [x] I have created a unit test.
- [x] I have provided a recording