### PR TITLE
Fix: Display Profile Photo for Assigned Bounties on User Profiles

### DIFF
--- a/src/people/widgetViews/UserTicketsView.tsx
+++ b/src/people/widgetViews/UserTicketsView.tsx
@@ -129,7 +129,7 @@ const UserTickets = () => {
   const listItems =
     displayedBounties && displayedBounties.length ? (
       displayedBounties.map((item: any, i: number) => {
-        const person = main.people.find((p: any) => p.owner_pubkey === item.body.owner_id);
+        const { person } = item;
         const body = { ...item.body };
         return (
           <Panel


### PR DESCRIPTION
### Problem:
A bug has been identified where the profile photo of the creator is not displayed when viewing assigned bounties from specific user profiles on the Sphinx Community platform. This issue does not occur consistently across all profiles, which suggests variability in the bug's manifestation.

### Expected Behavior:
The expected behavior is that the profile photo of the creator should be displayed correctly for all assigned bounties in user profiles. Users should be able to view the creator's profile photo consistently without encountering missing images.

## Issue ticket number and link:
- **Ticket Number:** [ 336 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/336 ]

### Evidence:
 Please see the attached video as evidence.
 https://www.loom.com/share/bef8d9b36e774f4b9ccf95491ef0fd6f

### Testing:
**Browser Compatibility:**
- Extensively tested on Chrome to ensure the fixes work as expected and the behavior is consistent across various test cases.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested on Chrome
- [x] I have provided a recording