### PR TITLE
Fixed: Clear Search Box on People Page When Clicking Back Arrow Button

### DIFF
--- a/src/pages/people/peopleList/PeopleList.tsx
+++ b/src/pages/people/peopleList/PeopleList.tsx
@@ -80,6 +80,7 @@ export const PeopleList = observer(() => {
 
   function goBack() {
     ui.setSelectingPerson(0);
+    ui.setSearchText('');
     history.replace('/p');
   }
 

--- a/src/pages/people/peopleList/__tests__/PeopleList.spec.tsx
+++ b/src/pages/people/peopleList/__tests__/PeopleList.spec.tsx
@@ -1,0 +1,46 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { useStores } from '../../../../store';
+import { PeopleList } from '../../peopleList';
+
+jest.mock('store', () => ({
+  useStores: jest.fn()
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    replace: jest.fn()
+  })
+}));
+
+describe('PeopleList Component', () => {
+  it('clears the search bar when back arrow button is clicked', async () => {
+    const mockSetSearchText = jest.fn();
+    (useStores as jest.Mock).mockReturnValue({
+      ui: {
+        searchText: 'John Doe',
+        setSearchText: mockSetSearchText,
+        setSelectingPerson: jest.fn(),
+        setSelectedPerson: jest.fn()
+      },
+      main: {
+        getPeople: jest.fn(),
+        people: []
+      }
+    });
+
+    const history = createMemoryHistory();
+    const { getByText, getByPlaceholderText } = render(
+      <Router history={history}>
+        <PeopleList />
+      </Router>
+    );
+    expect(getByPlaceholderText('Search')).toHaveValue('John Doe');
+    fireEvent.click(getByText('Back'));
+    expect(mockSetSearchText).toHaveBeenCalledWith('');
+  });
+});


### PR DESCRIPTION
### Problem:
The search box on the People page retains its text even after the user clicks the back arrow button. This behavior is inconsistent with expected UI patterns where a back navigation should reset page state.

### Expected Behavior:
After clicking the back arrow button on the People page, the search box should be cleared, and the page should return to its normal state as if freshly navigated to.

## Issue ticket number and link:
- **Ticket Number:** [ 356 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/356 ]

### Solution:
The solution involved ensuring that the search text state is reset to an empty string when the back button's onClick event handler is triggered. This was achieved by modifying the `goBack` function within the `PeopleList` component to call `setSearchText('')`.

### Changes:
- Updated the `goBack` function in `PeopleList` component to clear the search text.
- Ensured that other related states (like selected person) are also reset appropriately to reflect a full return to the page's initial state.

### Evidence:
 Please see the attached video as evidence.
 https://www.loom.com/share/fb4bb0f3c72b4875be015ea21030ff4d

### Testing:
**Browser Compatibility:**
- Extensively tested on Chrome to ensure the fixes work as expected and the behavior is consistent across various test cases.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested on Chrome
- [x] I have created a unit test.
- [x] I have provided a recording