### PR TITLE
Make the Navigation Header Responsive

### DIFF
--- a/src/people/main/Header.tsx
+++ b/src/people/main/Header.tsx
@@ -83,8 +83,13 @@ const Imgg = styled.div<ImageProps>`
 
 const Tabs = styled.div`
   display: flex;
-  margin-left: 20px;
+  justify-content: space-around;
   height: 100%;
+  gap: 50px;
+
+  @media screen and (max-width: 990px) {
+    gap: 25px;
+  }
 `;
 
 const MTabs = styled.div`
@@ -97,7 +102,6 @@ interface TagProps {
 }
 const Tab = styled(Link)<TagProps>`
   display: flex;
-  margin-right: 50px;
   padding: 0 8px;
   color: ${(p: any) => (p.selected ? '#fff' : '#6B7A8D')};
   cursor: pointer;
@@ -454,7 +458,7 @@ function Header() {
             width: '100%'
           }}
         >
-          <Row style={{ height: '100%', marginBottom: '-2px' }}>
+          <Row style={{ height: '100%', marginBottom: '-2px', flex: 2 }}>
             <EuiHeaderSection grow={false}>
               <Img src="/static/people_logo.svg" />
             </EuiHeaderSection>

--- a/src/people/main/Header.tsx
+++ b/src/people/main/Header.tsx
@@ -83,6 +83,7 @@ const Imgg = styled.div<ImageProps>`
 
 const Tabs = styled.div`
   display: flex;
+  margin-left: 20px;
   justify-content: space-around;
   height: 100%;
   gap: 50px;


### PR DESCRIPTION
### Describe your changes

### Issue ticket number and link 

### closes: #376

- [x] The Navigation header is now unresponsive on smaller desktop screens and username is visible
- [x] Wrote a test to show that the username is visible from a desktop viewport width of 1440 - 950

### Evidence

### Test:
![test-responsiveness](https://github.com/stakwork/sphinx-tribes-frontend/assets/117433403/9879db00-a6fb-45b6-bdb1-46fff3a5490e)

### Recording 
https://www.loom.com/share/172d3a447a834b6e8451133dc5c82c0e?sid=c3d78ec7-45ca-4137-a724-519d8d11b80a

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend