### PR TITLE
fix bounty does navigate to the right page after creation when a user…

### DIFF
--- a/src/people/widgetViews/postBounty/PostModal.tsx
+++ b/src/people/widgetViews/postBounty/PostModal.tsx
@@ -31,7 +31,15 @@ export const PostModal: FC<PostModalProps> = observer(
 
     const getBountyData = useCallback(async () => {
       try {
-        const response = await main.getPeopleBounties();
+        const response = await main.getPeopleBounties({
+          page: 1,
+          resetPage: true,
+          ...{
+            Open: true,
+            Assigned: true,
+            Paid: true
+          }
+        });
         return response[0].body?.id;
       } catch (err) {
         console.log('e', err);


### PR DESCRIPTION
## Problem: 
- Bounty doesn't navigate to the right page after creation when a user is assigned

Close : #382

## Issue ticket number and link:
- Ticket Number:[ 382 ]
- Link: [ https://github.com/stakwork/sphinx-tribes-frontend/issues/382 ]

##Evidance 

https://www.loom.com/share/161d2268eeed4bd7ba5b180da218d807?sid=a05f8e8a-70c7-4d47-ab16-24c51ebb514d


### Testing:
**Browser Compatibility:**
- Extensively tested on Chrome to ensure the fixes work as expected and the behavior is consistent across various test cases.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Bug fixed
- [x] I have tested on Chrome
- [x] I have provided a recording

