### PR TITLE
[Fixed]: Cross Icon Appears Above Text in Search Bar Across `Tribes`, `People` and `Bots` When Typing Long Inputs

### DIFF
--- a/src/components/common/SearchTextInput.tsx
+++ b/src/components/common/SearchTextInput.tsx
@@ -19,7 +19,7 @@ const Text = styled.input`
   box-sizing: border-box;
   border-radius: 21px;
   padding-left: 20px;
-  padding-right: 10px;
+  padding-right: 26px;
   // width:100%;
   font-style: normal;
   font-weight: normal;
@@ -61,7 +61,7 @@ function SearchTextInput(props: SearchTextInputProps) {
         onChange={(e: any) => {
           setSearchValue(e.target.value);
           debounceValue = e.target.value;
-          debounce(doDelayedValueUpdate, 300);
+          debounce(doDelayedValueUpdate, 800);
         }}
         placeholder={'Search'}
         style={{ ...props.style, ...collapseStyles }}

--- a/src/pages/people/peopleList/PeopleList.tsx
+++ b/src/pages/people/peopleList/PeopleList.tsx
@@ -113,8 +113,7 @@ export const PeopleList = observer(() => {
             width: 120,
             height: 40,
             border: '1px solid #DDE1E5',
-            background: '#fff',
-            paddingRight: '26px'
+            background: '#fff'
           }}
           onChange={handleSearchChange}
         />


### PR DESCRIPTION
### Problem:
- When we type something long in the search bar, a cross icon appears above the text across all routes like `Tribes`, `People` and `Bots`.

- Additionally, people often search pages so quickly that they do not write a string in the proper way; after 3 or 4 words, they start searching.

### Expected Behavior:
When a user types something lengthy in the search bar, the cross icon should not obstruct the text. Instead, it should appear in a position that does not cover the text, ensuring all routes like `Tribes`, `People` and `Bots` are accessible and the user experience remains intuitive and unobstructed.

closes: #443

## Issue ticket number and link:
- **Ticket Number:** [ 443 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/443 ]

### Evidence:
 Please see the attached video as evidence.
https://www.loom.com/share/da81c4b9fc53491e93d3e03262c06d98

### Testing:
**Browser Compatibility:**
- Extensively tested on Chrome to ensure the fixes work as expected and the behavior is consistent across various test cases.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have tested on Chrome
- [x] I have provided a recording