### PR TITLE
Fix: Preserve Search Query in Search Bar When Navigating to People Tab and User Profile

### DIFF
--- a/src/people/main/Header.tsx
+++ b/src/people/main/Header.tsx
@@ -477,8 +477,8 @@ function Header() {
                       selected={selected}
                       onClick={(e: any) => {
                         e.preventDefault();
+                        ui.setSearchText('');
                         if (t.name === 'people') {
-                          ui.setSearchText('');
                           main.getPeople({ resetPage: true });
                         }
                         history.push(t.path);

--- a/src/people/main/Header.tsx
+++ b/src/people/main/Header.tsx
@@ -475,9 +475,13 @@ function Header() {
                       key={i}
                       to={t.path}
                       selected={selected}
-                      onClick={() => {
+                      onClick={(e: any) => {
+                        e.preventDefault();
+                        if (t.name === 'people') {
+                          ui.setSearchText('');
+                          main.getPeople({ resetPage: true });
+                        }
                         history.push(t.path);
-                        ui.searchText && ui.setSearchText('');
                         localStorage.setItem('key', t.path);
                       }}
                     >

--- a/src/people/main/__tests__/MainHeader.spec.tsx
+++ b/src/people/main/__tests__/MainHeader.spec.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
-import { observer } from 'mobx-react-lite';
 import Header from '../Header';
 
 jest.mock('../../../store', () => ({
-  useStores: jest.fn(() => ({
+  useStores: () => ({
     main: {
-      getIsAdmin: jest.fn(),
-      getSelf: jest.fn()
+      getIsAdmin: jest.fn().mockResolvedValue(false),
+      getSelf: jest.fn().mockResolvedValue({}),
+      getPeople: jest.fn().mockResolvedValue([])
     },
     ui: {
       meInfo: null,
@@ -20,17 +20,24 @@ jest.mock('../../../store', () => ({
       showSignIn: false,
       torFormBodyQR: ''
     }
-  }))
+  })
 }));
 
 describe('Header Component', () => {
   test('renders Header component', () => {
-    render(<MemoryRouter>{<Header />}</MemoryRouter>);
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
   });
 
-  test('clicking on the GetSphinxsBtn calls the correct handler', async () => {
-    render(<MemoryRouter>{<Header />}</MemoryRouter>);
-
+  test('clicking on the "Get Sphinx" button calls the correct handler', async () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
     const getSphinxsBtn = screen.getByText('Get Sphinx');
     fireEvent.click(getSphinxsBtn);
   });

--- a/src/people/userInfo/hooks.ts
+++ b/src/people/userInfo/hooks.ts
@@ -20,6 +20,7 @@ export const useUserInfo = () => {
     ui.setSelectingPerson(0);
     const path = localStorage.getItem('key');
     if (path) {
+      ui.setSearchText('');
       history.replace(path);
     } else {
       history.replace('/');


### PR DESCRIPTION
## Problem
When I search for anything in the search bar and click on the "People" tab, the search box clears, but the search history is preserved. Also, when I click on a user profile and then return to the "People" page, the search box is not cleared.

- **Bug Demo:** https://www.loom.com/share/2d81f8cd7aa641189523d5b3ed5476ce

### Evidence:
 Please see the attached video as evidence.
- **Fixed Demo:** https://www.loom.com/share/4d21e330b5974292a62f7606de291db7

Testing:
Manual testing was conducted to verify that the new integration works as expected.

![image](https://github.com/stakwork/sphinx-tribes-frontend/assets/160427254/d15b2183-3d96-4980-a17b-ebfc90da3e10)

![image](https://github.com/stakwork/sphinx-tribes-frontend/assets/160427254/d69d7523-29a2-4311-a825-149885132582)

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have tested on Chrome.
- [x] I have modify unit test.
- [x] I have provided a recording of changes in my PR.