### PR TITLE
Fixed: `Connect Card` Modal Behavior on People Page

### DIFF
--- a/src/people/utils/ConnectCard.tsx
+++ b/src/people/utils/ConnectCard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { ConnectCardProps } from 'people/interfaces';
 import { Button, Modal, QR } from '../../components/common';
@@ -92,7 +91,6 @@ export default function ConnectCard(props: ConnectCardProps) {
   const qrString = person && person?.owner_pubkey ? makeConnectQR(person?.owner_pubkey) : '';
   const ownerPubkey = person && person?.owner_pubkey ? `${person.owner_pubkey}` : '';
   const routeHint = person && person?.owner_route_hint ? `:${person.owner_route_hint}` : '';
-  const history = useHistory();
 
   return (
     <div onClick={(e: any) => e.stopPropagation()}>
@@ -100,7 +98,6 @@ export default function ConnectCard(props: ConnectCardProps) {
         style={props.modalStyle}
         overlayClick={() => {
           props.dismiss();
-          history.goBack();
         }}
         visible={visible}
       >


### PR DESCRIPTION
### Problem:
- Currently, when clicking outside the Connect modal on the People page `(/p)`, the user is redirected to the `/bounties` route instead of staying on the current page.

### Closes: #508
### Expected Behavior:
- When the user clicks outside the Connect modal, the modal should close, but the user should remain on the People page (/p), without being redirected to any other route.

## Issue ticket number and link:
- **Ticket Number:** [ 508 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/508 ]

### Evidence:
 - Please see the attached video as evidence.
 https://www.loom.com/share/8913a6c092a841bdadd090a841d957f5

### Testing:
- Navigate to the People page /p.
- Click on the Connect button on any user card to open the modal.
- Click outside the modal to close it.
- Verify that the modal closes and the user remains on the People page without any redirection.

## Checklist before requesting a review
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] I have provided a recording of changes in my PR.