### PR TITLE
Streamline User Flow - `Reveal Connection Codes`

### DIFF
--- a/cypress/e2e/34_signoutPostBounty.cy.ts
+++ b/cypress/e2e/34_signoutPostBounty.cy.ts
@@ -17,7 +17,7 @@ describe('Signed Out Post Bounty Flow ', () => {
     cy.contains('Post a Bounty').click();
     cy.wait(1000);
 
-    cy.contains('Sign in').click();
+    cy.contains('Sign in').click({ force: true });
     cy.wait(1000);
 
     cy.haves_phinx_login(activeUser);

--- a/cypress/e2e/34_signoutPostBounty.cy.ts
+++ b/cypress/e2e/34_signoutPostBounty.cy.ts
@@ -17,7 +17,7 @@ describe('Signed Out Post Bounty Flow ', () => {
     cy.contains('Post a Bounty').click();
     cy.wait(1000);
 
-    cy.contains('I have Sphinx').click();
+    cy.contains('Sign in').click();
     cy.wait(1000);
 
     cy.haves_phinx_login(activeUser);

--- a/cypress/e2e/35_signoutConnectionCodes.cy.ts
+++ b/cypress/e2e/35_signoutConnectionCodes.cy.ts
@@ -9,9 +9,6 @@ describe('Sign Out Connection Codes', () => {
     cy.contains('Post a Bounty').click();
     cy.wait(1000);
 
-    cy.get('button.euiButton:contains("Get Sphinx")').click();
-    cy.wait(1000);
-
     cy.contains('Reveal Connection Code').click();
     cy.wait(1000);
 

--- a/cypress/e2e/36_icanhelpFLow.cy.ts
+++ b/cypress/e2e/36_icanhelpFLow.cy.ts
@@ -36,7 +36,7 @@ describe('I Can Help Flow', () => {
     cy.contains('I can help').click();
     cy.wait(600);
 
-    cy.contains('I have Sphinx').click();
+    cy.contains('Sign in').click();
     cy.wait(600);
 
     cy.login(secondUser);

--- a/cypress/e2e/36_icanhelpFLow.cy.ts
+++ b/cypress/e2e/36_icanhelpFLow.cy.ts
@@ -36,7 +36,7 @@ describe('I Can Help Flow', () => {
     cy.contains('I can help').click();
     cy.wait(600);
 
-    cy.contains('Sign in').click();
+    cy.contains('Sign in').click({ force: true });
     cy.wait(600);
 
     cy.login(secondUser);

--- a/src/people/main/__tests__/Header.spec.tsx
+++ b/src/people/main/__tests__/Header.spec.tsx
@@ -152,7 +152,7 @@ describe('AboutView Component', () => {
       );
       fireEvent.click(getByText('Get Sphinx'));
       await waitFor(() => {
-        const iHaveSphinxButton = screen.getByText('I have Sphinx');
+        const iHaveSphinxButton = screen.getByText('Sign in');
         expect(iHaveSphinxButton).toBeInTheDocument();
       });
     });

--- a/src/people/utils/StartUpModal.tsx
+++ b/src/people/utils/StartUpModal.tsx
@@ -44,7 +44,7 @@ const DirectionWrap = styled.div`
   padding: 0px;
   display: flex;
   width: 100%;
-  gap: 0.5rem;
+  justify-content: center;
 `;
 
 const AndroidIosButtonConatiner = styled.div`
@@ -57,9 +57,9 @@ const AndroidIosButtonConatiner = styled.div`
 
 const palette = colors.light;
 
-const StartUpModal = ({ closeModal, dataObject, buttonColor }: StartUpModalProps) => {
+const StartUpModal = ({ closeModal, buttonColor }: StartUpModalProps) => {
   const { ui } = useStores();
-  const [step, setStep] = useState(1);
+  const [step, setStep] = useState(2);
   const [connection_string, setConnectionString] = useState('');
 
   async function getConnectionCode() {
@@ -104,64 +104,6 @@ const StartUpModal = ({ closeModal, dataObject, buttonColor }: StartUpModalProps
           }}
           color={buttonColor}
         />
-      </ButtonContainer>
-    </>
-  );
-
-  const StepOne = () => (
-    <>
-      <ModalContainer data-testid="step-one">
-        <img
-          src={
-            dataObject === 'getWork'
-              ? '/static/create_profile_blue.gif'
-              : '/static/create_profile_green.gif'
-          }
-          height={'274px'}
-          alt=""
-        />
-      </ModalContainer>
-      <ButtonContainer>
-        <DirectionWrap style={{ justifyContent: 'space-around' }}>
-          <IconButton
-            text={'I have Sphinx'}
-            width={150}
-            height={48}
-            style={{ marginTop: '20px' }}
-            onClick={(e: any) => {
-              e.stopPropagation();
-              closeModal();
-              ui.setShowSignIn(true);
-            }}
-            textStyle={{
-              fontSize: '15px',
-              fontWeight: '500'
-            }}
-            iconStyle={{
-              top: '14px'
-            }}
-            color={buttonColor}
-          />
-
-          <IconButton
-            text={'Get Sphinx'}
-            width={150}
-            height={48}
-            style={{ marginTop: '20px', textDecoration: 'none' }}
-            onClick={(e: any) => {
-              e.stopPropagation();
-              setStep(step + 1);
-            }}
-            textStyle={{
-              fontSize: '15px',
-              fontWeight: '500'
-            }}
-            iconStyle={{
-              top: '14px'
-            }}
-            color={buttonColor}
-          />
-        </DirectionWrap>
       </ButtonContainer>
     </>
   );
@@ -230,26 +172,6 @@ const StartUpModal = ({ closeModal, dataObject, buttonColor }: StartUpModalProps
         />
         <DirectionWrap>
           <IconButton
-            text={'Back'}
-            width={210}
-            height={48}
-            buttonType={'text'}
-            style={{ color: '#83878b', marginTop: '20px', textDecoration: 'none' }}
-            onClick={(e: any) => {
-              e.stopPropagation();
-              setStep(step - 1);
-            }}
-            textStyle={{
-              fontSize: '15px',
-              fontWeight: '500',
-              color: '#5F6368'
-            }}
-            iconStyle={{
-              top: '14px'
-            }}
-            color={buttonColor}
-          />
-          <IconButton
             text={'Sign in'}
             width={210}
             height={48}
@@ -257,7 +179,8 @@ const StartUpModal = ({ closeModal, dataObject, buttonColor }: StartUpModalProps
             style={{ color: '#83878b', marginTop: '20px', textDecoration: 'none' }}
             onClick={(e: any) => {
               e.stopPropagation();
-              setStep(3);
+              closeModal();
+              ui.setShowSignIn(true);
             }}
             textStyle={{
               fontSize: '15px',
@@ -274,62 +197,10 @@ const StartUpModal = ({ closeModal, dataObject, buttonColor }: StartUpModalProps
     </>
   );
 
-  const StepThree = () => (
-    <ButtonContainer>
-      <IconButton
-        text={'Sign in'}
-        endingIcon={'arrow_forward'}
-        width={210}
-        height={48}
-        style={{ marginTop: 0 }}
-        hovercolor={buttonColor === 'primary' ? '#5881F8' : '#3CBE88'}
-        activecolor={buttonColor === 'primary' ? '#5078F2' : '#2FB379'}
-        shadowcolor={
-          buttonColor === 'primary' ? 'rgba(97, 138, 255, 0.5)' : 'rgba(73, 201, 152, 0.5)'
-        }
-        onClick={(e: any) => {
-          e.stopPropagation();
-          closeModal();
-          ui.setShowSignIn(true);
-        }}
-        color={buttonColor}
-      />
-
-      <IconButton
-        text={'Back'}
-        width={210}
-        height={48}
-        buttonType={'text'}
-        style={{ color: '#83878b', marginTop: '20px', textDecoration: 'none' }}
-        onClick={(e: any) => {
-          e.stopPropagation();
-          setStep(step - 1);
-        }}
-        textStyle={{
-          fontSize: '15px',
-          fontWeight: '500',
-          color: '#5F6368'
-        }}
-        iconStyle={{
-          top: '14px'
-        }}
-        color={buttonColor}
-      />
-    </ButtonContainer>
-  );
-
   return (
     <BaseModal data-testid="startup-modal" open onClose={closeModal}>
       <Box p={4} bgcolor={palette.grayish.G950} borderRadius={2} maxWidth={400} minWidth={350}>
-        {step === 1 ? (
-          <StepOne />
-        ) : step === 2 ? (
-          <StepTwo />
-        ) : step === 3 ? (
-          <StepThree />
-        ) : (
-          <DisplayQRCode />
-        )}
+        {step === 2 ? <StepTwo /> : <DisplayQRCode />}
       </Box>
     </BaseModal>
   );

--- a/src/people/widgetViews/__tests__/BountyHeader.spec.tsx
+++ b/src/people/widgetViews/__tests__/BountyHeader.spec.tsx
@@ -270,7 +270,7 @@ describe('BountyHeader Component', () => {
     const postBountyButton = screen.getByText('Post a Bounty');
     fireEvent.click(postBountyButton);
 
-    const modalButton = screen.getByText('Get Sphinx');
+    const modalButton = screen.getByText('Sign in');
     expect(modalButton).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Describe changes:
- Step - 1 is redundant as the user has already made this choice
- Remove `Back` Button for Step - 2 and `Sign in` Button center aligned
- Remove Step - 3


closes: #609

## Issue ticket number and link:
- **Ticket Number:** [ 609 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/609 ]

### Evidence:

![flow](https://github.com/user-attachments/assets/e6c7cf69-2631-43c4-bb29-1ea6286b5bc6)

https://www.loom.com/share/d8ab93cbc83e4ffd94cf38f8aac06a16


### Unit Test:

![image](https://github.com/user-attachments/assets/511c224d-c332-44a9-83dc-9b70da4406ff)

![image](https://github.com/user-attachments/assets/0497cb82-1697-4db1-9832-7666ce43f79c)

### Acceptance Criteria:
- [x] Record loom video of the change and attached to pull request or ticket on close.
- [x] Clicking "Get Sphinx" on the main page immediately shows the Step 2 modal
- [x] No step 1 is visible
- [x] All existing functionality in Step 2 remains unchanged:
    - [x] App download option works
    - [x] Connection code reveal works
    - [ ] "Sign in" button redirect works


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot of changes in my PR