### PR TITLE
Fixed[Bug]: New `Private` Bounties - On Accept Displays Last Public Bounty

### DIFF
--- a/src/people/widgetViews/postBounty/PostModal.tsx
+++ b/src/people/widgetViews/postBounty/PostModal.tsx
@@ -8,8 +8,10 @@ import { useStores } from '../../../store';
 import FocusedView from '../../main/FocusView';
 import { Widget } from '../../main/types';
 import { widgetConfigs } from '../../utils/Constants';
+import { PersonBounty } from '../../../store/interface';
 
 const color = colors['light'];
+
 export interface PostModalProps {
   isOpen: boolean;
   widget: Widget;
@@ -18,6 +20,7 @@ export interface PostModalProps {
   onGoBack?: () => void;
   phase_uuid?: string;
 }
+
 export const PostModal: FC<PostModalProps> = observer(
   ({ isOpen, onClose, widget, onGoBack, onSucces, phase_uuid }: any) => {
     const { main, ui } = useStores();
@@ -48,13 +51,19 @@ export const PostModal: FC<PostModalProps> = observer(
     }, [main]);
 
     const ReCallBounties = async () => {
-      /*
-      TODO : after getting the better way to reload the bounty, this code will be removed.
-      */
-      const number = await getBountyData();
+      const createdBounties = await main.getPersonCreatedBounties(
+        { page: 1, resetPage: true },
+        person?.uuid
+      );
 
-      if (number) {
-        history.push(`/bounty/${number}`);
+      const [mostRecentBounty] = createdBounties.sort(
+        (a: PersonBounty, b: PersonBounty) =>
+          new Date(b.body?.created).getTime() - new Date(a.body?.created).getTime()
+      );
+
+      const bountyId = mostRecentBounty?.body?.id || (await getBountyData());
+      if (bountyId) {
+        history.push(`/bounty/${bountyId}`);
       }
     };
 
@@ -90,7 +99,6 @@ export const PostModal: FC<PostModalProps> = observer(
     }
     return (
       <>
-        {' '}
         {isOpen && (
           <Modal
             visible={isOpen}


### PR DESCRIPTION
### Describe the bug:
- reate a bounty, fill out details. Don't publicly broadcast and assign privately.
When you exit out of the process - the user is shown the preview of the last public bounty that was on the site.

closes: #614

## Issue ticket number and link:
- **Ticket Number:** [ 614 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/614 ]

### Evidence:

https://www.loom.com/share/95d96f7d959043f2b5036b832e51ae07

![image](https://github.com/user-attachments/assets/7b67aa64-7f4a-4e6f-8684-60a578d48fbe)


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have provided a screenshot of changes in my PR