### PR TITLE
Fixed[Bug]: `Completed` Bounties Incorrectly Displayed as `Assigned` in `Mobile View`

### DIFF
--- a/src/people/widgetViews/wantedViews/MobileView.tsx
+++ b/src/people/widgetViews/wantedViews/MobileView.tsx
@@ -41,7 +41,8 @@ function MobileView(props: any) {
     show,
     paid,
     isMine,
-    titleString
+    titleString,
+    completed
   } = props;
 
   const { ui, main } = useStores();
@@ -107,6 +108,7 @@ function MobileView(props: any) {
                   marginTop: 10
                 }}
                 paid={paid}
+                completed={completed}
               />
             )}
             {{ ...assignee }.owner_alias && (


### PR DESCRIPTION
### Describe the bug:
- In the mobile view, completed bounties are incorrectly shown as assigned. As a result, users are unable to distinguish which bounties have been completed.

closes: #621

## Issue ticket number and link:
- **Ticket Number:** [ 621 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/621 ]

### Evidence:

https://www.loom.com/share/b659105dd8f846619020910a4cd85025

![image](https://github.com/user-attachments/assets/0e65cb17-7a26-4447-a15b-c15d3c366fb5)

## **Expected behavior**
- Completed bounties should be clearly marked as `Completed` in the mobile view, allowing users to easily differentiate between completed and assigned bounties.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have provided a screenshot of changes in my PR