### PR TITLE
Fix Toast Feedback Persistence in Ticket Editor

### DIFF
--- a/src/components/common/TicketEditor/TicketEditor.tsx
+++ b/src/components/common/TicketEditor/TicketEditor.tsx
@@ -52,7 +52,7 @@ const TicketEditor = ({ ticketData }: TicketEditorProps) => {
   const addUpdateSuccessToast = () => {
     setToasts([
       {
-        id: '3',
+        id: `${Date.now()}-success`,
         title: 'Hive',
         color: 'success',
         text: 'Updates Saved!'
@@ -63,7 +63,7 @@ const TicketEditor = ({ ticketData }: TicketEditorProps) => {
   const addUpdateErrorToast = () => {
     setToasts([
       {
-        id: '4',
+        id: `${Date.now()}-error`,
         title: 'Hive',
         color: 'danger',
         text: 'We had an issue, try again!'
@@ -96,7 +96,7 @@ const TicketEditor = ({ ticketData }: TicketEditorProps) => {
   const addSuccessToast = () => {
     setToasts([
       {
-        id: '1',
+        id: `${Date.now()}-ticket-success`,
         title: 'Ticket Builder',
         color: 'success',
         text: "Success, I'll rewrite your ticket now!"
@@ -107,7 +107,7 @@ const TicketEditor = ({ ticketData }: TicketEditorProps) => {
   const addErrorToast = () => {
     setToasts([
       {
-        id: '2',
+        id: `${Date.now()}-ticket-error`,
         title: 'Ticket Builder',
         color: 'danger',
         text: 'Sorry, there appears to be a problem'


### PR DESCRIPTION
### Describe the Changes:
- Added toast notifications to the Ticket Update for success and error feedback upon submission to the `/bounties/ticket/uuid` endpoint.

closes: #694

## Issue ticket number and link:
- **Ticket Number:** [ 694 ]
- **Link:** [ https://github.com/stakwork/sphinx-tribes-frontend/issues/694 ]

### Evidence:

![image](https://github.com/user-attachments/assets/82c429c0-500e-4fbd-beb5-c9d16c4ae9cc)

![image](https://github.com/user-attachments/assets/87b349bb-61d1-42a4-9609-4a2678b87a47)


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot of changes in my PR