### PR TITLE
Feat: Increase Bounty List Pagination to 25 Items Per Page

### DIFF
--- a/src/store/__test__/main.spec.ts
+++ b/src/store/__test__/main.spec.ts
@@ -1191,7 +1191,7 @@ describe('Main store', () => {
   it('should return filter by languages, status response', async () => {
     const store = new MainStore();
     const filterCriteria = {
-      limit: 10,
+      limit: 25,
       page: 1,
       sortBy: 'created',
       coding_languages: 'Typescript',

--- a/src/store/__test__/main.spec.ts
+++ b/src/store/__test__/main.spec.ts
@@ -1188,7 +1188,7 @@ describe('Main store', () => {
     });
   });
 
-  it('should return filter by languages, status response', async () => {
+  it('should return filter by the languages, status, and other criteria', async () => {
     const store = new MainStore();
     const filterCriteria = {
       limit: 25,

--- a/src/store/interface.ts
+++ b/src/store/interface.ts
@@ -391,9 +391,9 @@ export const defaultBountyStatus: BountyStatus = {
 };
 
 export const queryLimitTribes = 100;
-export const queryLimit = 10;
+export const queryLimit = 25;
 export const orgQuerLimit = 500;
-export const paginationQueryLimit = 20;
+export const paginationQueryLimit = 25;
 export const peopleQueryLimit = 500;
 export const featureLimit = 4;
 export const phaseBountyLimit = 3;


### PR DESCRIPTION
### Describe the Changes:

Increased the default pagination limit 25 bounties per page
  - Affects all bounty list views including:
  - Global bounty list `(/bounties)`
  - Workspace bounty lists `(/workspace/bounties/<workspaceID>)`
  - Personal bounty lists `(/p/<personID>/bounties)`
  - Assigned bounty lists `(/p/<personID>/assigned)`

Daily Bounty: https://community.sphinx.chat/bounty/3175

## Bounty number and link:
- **Bounty Number:** [  3175 ]
- **Link:** [ https://community.sphinx.chat/bounty/3175 ]

### Evidence:

https://www.loom.com/share/84f06356c48d46d7b68d599ef901b118

![image](https://github.com/user-attachments/assets/cd8fb49c-9c7d-47fc-9ff3-86773469af1c)

![image](https://github.com/user-attachments/assets/4fc2d395-8317-4713-b909-31f4878e41d5)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have provided a screenshot and video of changes in my PR
- [x] I have tested on Chrome and other Browsers
- [x] New feature (non-breaking change which adds functionality)
