### PR TITLE
Implemented Chat archive functionality with confirmation modal

### DIFF
--- a/src/components/common/ChatArchiveConfirmationModal/index.tsx
+++ b/src/components/common/ChatArchiveConfirmationModal/index.tsx
@@ -1,0 +1,67 @@
+import React, { PropsWithChildren } from 'react';
+import { Stack } from '@mui/system';
+import MaterialIcon from '@material/react-material-icon';
+import { colors } from 'config';
+import { BaseModal } from '../BaseModal';
+import IconButton from '../IconButton2';
+import { useCreateModal } from '../useCreateModal';
+
+export type ChatArchiveConfirmationModalProps = PropsWithChildren<{
+  onClose: () => void;
+  onConfirmArchive: () => void;
+  onCancel?: () => void;
+}>;
+
+export const ChatArchiveConfirmationModal = ({
+  onClose,
+  children,
+  onCancel,
+  onConfirmArchive
+}: ChatArchiveConfirmationModalProps) => {
+  const closeHandler = () => {
+    onClose();
+    onCancel?.();
+  };
+
+  const confirmArchiveHandler = () => {
+    onConfirmArchive();
+    onClose();
+  };
+
+  return (
+    <BaseModal backdrop="white" open onClose={closeHandler}>
+      <Stack minWidth={350} p={4} alignItems="center" spacing={3}>
+        <MaterialIcon
+          icon="archive"
+          className="MaterialIcon"
+          style={{ fontSize: 32, color: colors['light'].grayish.G300 }}
+        />
+        {children}
+        <Stack width="100%" direction="row" justifyContent="space-between">
+          <IconButton width={120} height={44} color="white" text="Cancel" onClick={closeHandler} />
+          <IconButton
+            width={120}
+            height={44}
+            color="danger"
+            text="Archive"
+            dataTestId="archive-confirmation"
+            onClick={confirmArchiveHandler}
+          />
+        </Stack>
+      </Stack>
+    </BaseModal>
+  );
+};
+
+export const useChatArchiveConfirmationModal = () => {
+  const openModal = useCreateModal();
+
+  const openArchiveConfirmation = (props: Omit<ChatArchiveConfirmationModalProps, 'onClose'>) => {
+    openModal({
+      Component: ChatArchiveConfirmationModal,
+      props
+    });
+  };
+
+  return { openArchiveConfirmation };
+};

--- a/src/pages/tickets/style.ts
+++ b/src/pages/tickets/style.ts
@@ -410,6 +410,7 @@ export const Input = styled.input`
 export const EditPopover = styled.div`
   position: relative;
   display: inline-block;
+  z-index: 1;
 `;
 
 export const EditPopoverContent = styled.div<EditPopoverContentProps>`

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -188,6 +188,37 @@ export class ChatService {
       return undefined;
     }
   }
+
+  async archiveChat(chat_id: string): Promise<boolean> {
+    try {
+      if (!uiStore.meInfo) return false;
+      const info = uiStore.meInfo;
+
+      const response = await fetch(`${TribesURL}/hivechat/${chat_id}/archive`, {
+        method: 'PUT',
+        mode: 'cors',
+        headers: {
+          'x-jwt': info.tribe_jwt,
+          'Content-Type': 'application/json'
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const result = await response.json();
+
+      if (!result.success) {
+        throw new Error('Invalid archive chat response');
+      }
+
+      return true;
+    } catch (e) {
+      console.error('Error archiving chat:', e);
+      return false;
+    }
+  }
 }
 
 export const chatService = new ChatService();

--- a/src/store/chat.ts
+++ b/src/store/chat.ts
@@ -19,6 +19,8 @@ export interface ChatStore {
   addMessage: (message: ChatMessage) => void;
   updateMessage: (id: string, message: Partial<ChatMessage>) => void;
   getWorkspaceChats: (workspace_uuid: string) => Promise<Chat[]>;
+  archiveChat: (chat_id: string) => Promise<boolean>;
+  removeChat: (chat_id: string) => void;
 }
 
 export class ChatHistoryStore implements ChatStore {
@@ -176,6 +178,28 @@ export class ChatHistoryStore implements ChatStore {
     } catch (error) {
       console.error('Error sending message:', error);
       return undefined;
+    }
+  }
+
+  removeChat(chat_id: string) {
+    this.chats.delete(chat_id);
+    delete this.chatMessages[chat_id];
+    if (this.currentChatId === chat_id) {
+      this.currentChatId = null;
+    }
+  }
+
+  async archiveChat(chat_id: string): Promise<boolean> {
+    try {
+      const success = await chatService.archiveChat(chat_id);
+      if (success) {
+        this.removeChat(chat_id);
+        return true;
+      }
+      return false;
+    } catch (error) {
+      console.error('Error archiving chat:', error);
+      return false;
     }
   }
 }


### PR DESCRIPTION
### Describe your changes

Implemented Chat archive functionality with confirmation modal

### Bounty link
https://community.sphinx.chat/bounty/3206


### Loom:
https://www.loom.com/share/91b6b8b2bb724cdfbbcd70b152038828?sid=36317154-4e1f-4f9b-8c9c-cabbccae9968

### Screenshots

<img width="548" alt="Screenshot 2025-01-08 at 12 31 33 PM" src="https://github.com/user-attachments/assets/f503604e-d22b-4544-ac12-745509a6b7d1" />

<img width="320" alt="Screenshot 2025-01-08 at 12 14 25 PM" src="https://github.com/user-attachments/assets/03e3eea7-918c-41d6-b564-6117e580fd34" />

<img width="607" alt="Screenshot 2025-01-08 at 12 14 06 PM" src="https://github.com/user-attachments/assets/cba04784-72fb-4549-baf4-880fe53dbed2" />

<img width="427" alt="Screenshot 2025-01-08 at 12 33 36 PM" src="https://github.com/user-attachments/assets/85f6f25d-b50f-4a07-be49-e2dabdd2354c" />

<img width="381" alt="test" src="https://github.com/user-attachments/assets/9b59f02c-1925-4688-8db3-f4ac4e2802d9" />


### Check list
- [x] Ensured that two menus cannot be opened at the same time
- [x] Three-dot menu appears on each chat item
- [x] Clicking menu opens dropdown with "Archive" option
- [x] Confirmation modal appears before archiving
- [x] Successful archive removes chat from list
- [x] Success toast appears after successful archive
- [x] Error toast appears after failed archive
- [x] Chat list refreshes automatically after archive
- [x] Failed archive shows error message
- [x] Loading states are handled appropriately
- [x] Error states are handled gracefully
- [x] Maintain consistent styling with existing UI