### PR TITLE
 Implement planner filters for phase and status

### DIFF
--- a/src/people/WorkSpacePlanner/WorkspacePlannerHeader/index.tsx
+++ b/src/people/WorkSpacePlanner/WorkspacePlannerHeader/index.tsx
@@ -3,7 +3,7 @@ import { EuiText, EuiPopover, EuiCheckboxGroup } from '@elastic/eui';
 import MaterialIcon from '@material/react-material-icon';
 import { observer } from 'mobx-react-lite';
 import styled from 'styled-components';
-import { Workspace, Feature, BountyCard } from 'store/interface';
+import { Workspace, Feature, BountyCard, BountyCardStatus, STATUS_LABELS } from 'store/interface';
 import { useStores } from '../../../store';
 import { userCanManageBounty } from '../../../helpers';
 import { PostModal } from '../../widgetViews/postBounty/PostModal';
@@ -44,6 +44,16 @@ interface WorkspacePlannerHeaderProps {
   setFilterToggle: (a: boolean) => void;
 }
 
+interface Option {
+  label: string;
+  id: string;
+}
+
+interface StatusOption {
+  label: string;
+  id: BountyCardStatus;
+}
+
 interface FeatureOption {
   label: string;
   id: string;
@@ -74,6 +84,8 @@ export const WorkspacePlannerHeader = observer(
     const [isPostBountyModalOpen, setIsPostBountyModalOpen] = useState(false);
     const [canPostBounty, setCanPostBounty] = useState(false);
     const [isFeaturePopoverOpen, setIsFeaturePopoverOpen] = useState<boolean>(false);
+    const [isPhasePopoverOpen, setIsPhasePopoverOpen] = useState<boolean>(false);
+    const [isStatusPopoverOpen, setIsStatusPopoverOpen] = useState<boolean>(false);
     const bountyCardStore = useBountyCardStore(workspace_uuid);
 
     const checkUserPermissions = useCallback(async () => {
@@ -144,6 +156,67 @@ export const WorkspacePlannerHeader = observer(
       }
 
       return options;
+    };
+
+    const getPhaseOptions = (): Option[] => {
+      if (bountyCardStore.selectedFeatures.length === 0) {
+        return [];
+      }
+
+      const options: Option[] = [];
+      const uniquePhases = new Map<string, { name: string; count: number }>();
+
+      bountyCardStore.filteredByFeatures.forEach((card: BountyCard) => {
+        if (card.phase?.uuid && card.phase?.name) {
+          const existing = uniquePhases.get(card.phase?.uuid);
+          if (existing) {
+            existing.count++;
+          } else {
+            uniquePhases.set(card.phase?.uuid, {
+              name: card.phase.name,
+              count: 1
+            });
+          }
+        }
+      });
+
+      uniquePhases.forEach((value: { name: string; count: number }, id: string) => {
+        options.push({
+          label: `${value.name} (${value.count})`,
+          id
+        });
+      });
+
+      return options.sort((a: Option, b: Option) => a.label.localeCompare(b.label));
+    };
+
+    const getStatusOptions = (): StatusOption[] => {
+      const initialCounts: Record<BountyCardStatus, number> = {
+        TODO: 0,
+        IN_PROGRESS: 0,
+        IN_REVIEW: 0,
+        COMPLETED: 0,
+        PAID: 0
+      };
+
+      const statusCounts = bountyCardStore.filteredByFeatures.reduce<
+        Record<BountyCardStatus, number>
+      >(
+        (acc: Record<BountyCardStatus, number>, card: BountyCard) => {
+          if (card.status) {
+            acc[card.status] = (acc[card.status] || 0) + 1;
+          }
+          return acc;
+        },
+        { ...initialCounts }
+      );
+
+      return (Object.entries(statusCounts) as [BountyCardStatus, number][]).map(
+        ([status, count]: [BountyCardStatus, number]): StatusOption => ({
+          label: `${STATUS_LABELS[status]} (${count})`,
+          id: status
+        })
+      );
     };
 
     return (
@@ -276,26 +349,196 @@ export const WorkspacePlannerHeader = observer(
                 </EuiPopover>
               </NewStatusContainer>
 
-              <NewStatusContainer>
-                <StatusContainer color={color}>
-                  <InnerContainer>
-                    <EuiText className="statusText">Phase</EuiText>
-                    <div className="filterStatusIconContainer">
-                      <MaterialIcon className="materialStatusIcon" icon="keyboard_arrow_down" />
-                    </div>
-                  </InnerContainer>
-                </StatusContainer>
+              <NewStatusContainer
+                style={{
+                  cursor: bountyCardStore.selectedFeatures.length === 0 ? 'not-allowed' : 'pointer'
+                }}
+              >
+                <EuiPopover
+                  button={
+                    <StatusContainer
+                      onClick={() => setIsPhasePopoverOpen(!isPhasePopoverOpen)}
+                      color={color}
+                      style={{
+                        ...(bountyCardStore.selectedFeatures.length === 0
+                          ? {
+                              cursor: 'not-allowed',
+                              pointerEvents: 'none'
+                            }
+                          : {})
+                      }}
+                    >
+                      <InnerContainer>
+                        <EuiText
+                          className="statusText"
+                          style={{
+                            color: isPhasePopoverOpen ? color.grayish.G10 : '',
+                            opacity: bountyCardStore.selectedFeatures.length === 0 ? 0.5 : 1
+                          }}
+                        >
+                          Phase
+                        </EuiText>
+                        <Formatter>
+                          {bountyCardStore.selectedPhases.length > 0 && (
+                            <FilterCount color={color}>
+                              <EuiText className="filterCountText">
+                                {bountyCardStore.selectedPhases.length}
+                              </EuiText>
+                            </FilterCount>
+                          )}
+                        </Formatter>
+                        <div className="filterStatusIconContainer">
+                          <MaterialIcon
+                            className="materialStatusIcon"
+                            icon={isPhasePopoverOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+                            style={{
+                              color: isPhasePopoverOpen ? color.grayish.G10 : '',
+                              opacity: bountyCardStore.selectedFeatures.length === 0 ? 0.5 : 1
+                            }}
+                          />
+                        </div>
+                      </InnerContainer>
+                    </StatusContainer>
+                  }
+                  isOpen={isPhasePopoverOpen}
+                  closePopover={() => setIsPhasePopoverOpen(false)}
+                  panelPaddingSize="none"
+                  anchorPosition="downLeft"
+                  panelStyle={{
+                    border: 'none',
+                    boxShadow: `0px 1px 20px ${color.black90}`,
+                    background: color.pureWhite,
+                    borderRadius: '0px 0px 6px 6px',
+                    maxWidth: '140px',
+                    minHeight: '160px',
+                    marginTop: '0px',
+                    marginLeft: '20px'
+                  }}
+                >
+                  <EuiPopOverCheckbox className="CheckboxOuter" color={color}>
+                    <EuiCheckboxGroup
+                      options={getPhaseOptions()}
+                      idToSelectedMap={bountyCardStore.selectedPhases.reduce(
+                        (acc: { [key: string]: boolean }, phaseId: string) => {
+                          acc[phaseId] = true;
+                          return acc;
+                        },
+                        {}
+                      )}
+                      onChange={(id: string) => {
+                        bountyCardStore.togglePhase(id);
+                        setFilterToggle(!filterToggle);
+                      }}
+                    />
+                    {bountyCardStore.selectedPhases.length > 0 && (
+                      <div
+                        style={{
+                          padding: '8px 16px',
+                          borderTop: `1px solid ${color.grayish.G800}`
+                        }}
+                      >
+                        <ClearButton
+                          onClick={() => {
+                            bountyCardStore.selectedPhases = [];
+                            bountyCardStore.saveFilterState();
+                            setFilterToggle(!filterToggle);
+                          }}
+                        >
+                          Clear All
+                        </ClearButton>
+                      </div>
+                    )}
+                  </EuiPopOverCheckbox>
+                </EuiPopover>
               </NewStatusContainer>
 
               <NewStatusContainer>
-                <StatusContainer color={color}>
-                  <InnerContainer>
-                    <EuiText className="statusText">Status</EuiText>
-                    <div className="filterStatusIconContainer">
-                      <MaterialIcon className="materialStatusIcon" icon="keyboard_arrow_down" />
-                    </div>
-                  </InnerContainer>
-                </StatusContainer>
+                <EuiPopover
+                  button={
+                    <StatusContainer
+                      onClick={() => setIsStatusPopoverOpen(!isStatusPopoverOpen)}
+                      color={color}
+                    >
+                      <InnerContainer>
+                        <EuiText
+                          className="statusText"
+                          style={{
+                            color: isStatusPopoverOpen ? color.grayish.G10 : ''
+                          }}
+                        >
+                          Status
+                        </EuiText>
+                        <Formatter>
+                          {bountyCardStore.selectedStatuses.length > 0 && (
+                            <FilterCount color={color}>
+                              <EuiText className="filterCountText">
+                                {bountyCardStore.selectedStatuses.length}
+                              </EuiText>
+                            </FilterCount>
+                          )}
+                        </Formatter>
+                        <div className="filterStatusIconContainer">
+                          <MaterialIcon
+                            className="materialStatusIcon"
+                            icon={isStatusPopoverOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+                            style={{
+                              color: isStatusPopoverOpen ? color.grayish.G10 : ''
+                            }}
+                          />
+                        </div>
+                      </InnerContainer>
+                    </StatusContainer>
+                  }
+                  isOpen={isStatusPopoverOpen}
+                  closePopover={() => setIsStatusPopoverOpen(false)}
+                  panelPaddingSize="none"
+                  anchorPosition="downLeft"
+                  panelStyle={{
+                    border: 'none',
+                    boxShadow: `0px 1px 20px ${color.black90}`,
+                    background: color.pureWhite,
+                    borderRadius: '0px 0px 6px 6px',
+                    maxWidth: '140px',
+                    minHeight: '160px',
+                    marginTop: '0px',
+                    marginLeft: '20px'
+                  }}
+                >
+                  <EuiPopOverCheckbox className="CheckboxOuter" color={color}>
+                    <EuiCheckboxGroup
+                      options={getStatusOptions()}
+                      idToSelectedMap={bountyCardStore.selectedStatuses.reduce(
+                        (acc: { [key: string]: boolean }, status: BountyCardStatus) => {
+                          acc[status] = true;
+                          return acc;
+                        },
+                        {}
+                      )}
+                      onChange={(id: string) => {
+                        bountyCardStore.toggleStatus(id as BountyCardStatus);
+                        setFilterToggle(!filterToggle);
+                      }}
+                    />
+                    {bountyCardStore.selectedStatuses.length > 0 && (
+                      <div
+                        style={{
+                          padding: '8px 16px',
+                          borderTop: `1px solid ${color.grayish.G800}`
+                        }}
+                      >
+                        <ClearButton
+                          onClick={() => {
+                            bountyCardStore.selectedStatuses = [];
+                            bountyCardStore.saveFilterState();
+                            setFilterToggle(!filterToggle);
+                          }}
+                        >
+                          Clear All
+                        </ClearButton>
+                      </div>
+                    )}
+                  </EuiPopOverCheckbox>
+                </EuiPopover>
               </NewStatusContainer>
             </FiltersRight>
           </Filters>

--- a/src/store/interface.ts
+++ b/src/store/interface.ts
@@ -471,6 +471,13 @@ export type ChatStatus = 'sending' | 'sent' | 'error';
 export type ContextTagType = 'productBrief' | 'featureBrief' | 'schematic';
 export type ChatSource = 'user' | 'agent';
 export type BountyCardStatus = 'TODO' | 'IN_PROGRESS' | 'IN_REVIEW' | 'COMPLETED' | 'PAID';
+export const STATUS_LABELS: Readonly<Record<BountyCardStatus, string>> = {
+  TODO: 'Todo',
+  IN_PROGRESS: 'In Progress',
+  IN_REVIEW: 'In Review',
+  COMPLETED: 'Completed',
+  PAID: 'Paid'
+} as const;
 
 export interface ContextTag {
   type: ContextTagType;


### PR DESCRIPTION
### Describe your changes

### Issue ticket number and link
•⁠  ⁠Link: https://community.sphinx.chat/bounty/3232
•⁠  ⁠Number: 3232

### Loom 

https://www.loom.com/share/f6ad2365b44e4a9f8d1c20a5cee5f652?sid=218b3caa-3ac9-4577-a030-d1fc1a123112

### Screenshots

<img width="253" alt="Screenshot 2025-01-09 at 1 36 52 PM" src="https://github.com/user-attachments/assets/e2bd40d4-b4f5-4d9d-a733-9ab4a625105c" />

<img width="225" alt="Screenshot 2025-01-09 at 1 40 38 PM" src="https://github.com/user-attachments/assets/10326d8a-aabe-4a6c-9e0b-73fceda9ee5c" />

<img width="366" alt="Screenshot 2025-01-09 at 1 41 09 PM" src="https://github.com/user-attachments/assets/063f7d50-05c5-43c6-9c09-65cbb04c7e6d" />



## Checklist 
 - [x] Loom tests attached to PR
 - [x] Phase filter is disabled by default and only becomes enabled when one or more features are selected and dynamically updating to show only those associated with the selected features
 - [x] When all features are unselected, the phase filter automatically disables and clears any selected phase filters
 Status filter remains independently functional regardless of feature/phase selections, allowing filtering across all possible statuses (TODO, IN_PROGRESS, IN_REVIEW, COMPLETED, PAID)
  - [x] All filter selections (features, phases, status) persist across page refreshes via session storage and are cleared appropriately when switching workspaces
 - [x] Cards displayed must match ALL selected filters simultaneously (feature AND phase AND status conditions)
 - [x] Each filter shows the current number of selected options and provides clear visual feedback of enabled/disabled states
 - [x] Edge cases are handled gracefully: cards without phases, all options selected, and empty filter selections defaulting to show all cards