### PR TITLE
Feature: Add `Purpose`, `Outcome`, and `Scope` Fields to PhasePlanner UI

### DIFF
--- a/src/people/widgetViews/workspace/interface.ts
+++ b/src/people/widgetViews/workspace/interface.ts
@@ -94,6 +94,9 @@ export interface Phase {
   feature_uuid: string;
   name: string;
   priority: number;
+  phase_purpose?: string;
+  phase_outcome?: string;
+  phase_scope?: string;
 }
 
 export type PhaseOperationType = 'create' | 'edit' | 'delete';


### PR DESCRIPTION
### Describe the Changes:
- Added Purpose, Outcome, and Scope fields with markdown edit/preview to PhasePlanner UI.

Daily Bounty: https://community.sphinx.chat/bounty/3281

## Issue ticket number and link:
- **Bounty Number:** [ 3281 ]
- **Link:** [ [https://community.sphinx.chat/bounty/3281](url) ]

### Evidence:

#### `Loom`

https://www.loom.com/share/4c99a9abb1da410aa844c40aaa7d1949

#### `Screenshots`

![image](https://github.com/user-attachments/assets/fc6134aa-1a4a-4c42-8633-c22056107b36)

![image](https://github.com/user-attachments/assets/c495acde-64a5-485b-bac3-a7033598891e)

![image](https://github.com/user-attachments/assets/4a50d00d-c062-4761-b8b7-3c6dba915345)

![image](https://github.com/user-attachments/assets/634da701-ed5c-4bff-a671-5df172f38e33)

![image](https://github.com/user-attachments/assets/439228eb-9b6c-4792-83a7-30ee8a092bbd)

![image](https://github.com/user-attachments/assets/2dd2d7e0-58c0-48ee-8720-4b74df934d58)

![image](https://github.com/user-attachments/assets/7be6ed35-1790-4e38-b9d2-90a0aec481c7)

![image](https://github.com/user-attachments/assets/1d8100a4-564e-4c9a-ab6b-20fdb0551da7)

![image](https://github.com/user-attachments/assets/e8dae5d1-43be-405c-8231-7a6951f77c1e)

![image](https://github.com/user-attachments/assets/3b0b4f31-2fd1-41d1-a5cc-aa4c11917b97)

![image](https://github.com/user-attachments/assets/29382759-047e-4e46-b278-4dab84f12672)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and demo of changes in my PR