### PR TITLE
Hide Empty Columns on Status Filter in Workspace Planner Board

### DIFF
--- a/src/people/WorkSpacePlanner/index.tsx
+++ b/src/people/WorkSpacePlanner/index.tsx
@@ -50,10 +50,14 @@ const ColumnsContainer = styled.div`
   }
 `;
 
-const Column = styled.div`
+interface ColumnProps {
+  hidden?: boolean;
+}
+
+const Column = styled.div<ColumnProps>`
   flex: 0 0 320px;
   border-radius: 8px;
-  display: flex;
+  display: ${(props: ColumnProps) => (props.hidden ? 'none' : 'flex')};
   flex-direction: column;
   height: auto;
   min-height: 500px;
@@ -199,6 +203,13 @@ const WorkspacePlanner = observer(() => {
     }
   };
 
+  const shouldShowColumn = (status: BountyCardStatus): boolean => {
+    if (bountyCardStore.selectedStatuses.length === 0) {
+      return true;
+    }
+    return bountyCardStore.selectedStatuses.includes(status);
+  };
+
   return (
     <PlannerContainer>
       <WorkspacePlannerHeader
@@ -212,7 +223,7 @@ const WorkspacePlanner = observer(() => {
       <ContentArea>
         <ColumnsContainer>
           {COLUMN_CONFIGS.map(({ id, title }: { id: string; title: string }) => (
-            <Column key={id}>
+            <Column key={id} hidden={!shouldShowColumn(id as BountyCardStatus)}>
               <ColumnHeader>
                 <ColumnTitle>
                   {title}


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link: https://community.sphinx.chat/p/csb7he2tu2rqjmn086ug/assigned/3395/0

## Evidence:

https://www.loom.com/share/78d0cdd459484fc3a2bcc65592aed711

![image](https://github.com/user-attachments/assets/2671d647-1d07-43df-905a-51ceef2c9edd)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device
- [ ] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend