### PR TITLE
Fixed: Workspace Planner `All Filters` Popover Overflow

### DIFF
--- a/src/people/WorkSpacePlanner/WorkspacePlannerHeader/index.tsx
+++ b/src/people/WorkSpacePlanner/WorkspacePlannerHeader/index.tsx
@@ -128,6 +128,32 @@ const SearchInput = ({
   </SearchInputContainer>
 );
 
+const ScrollablePopoverContent = styled.div`
+  max-height: 300px;
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  &::-webkit-scrollbar {
+    width: 3px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: ${colors.light.grayish.G800};
+    border-radius: 3px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${colors.light.grayish.G200};
+    border-radius: 3px;
+  }
+`;
+
+const CustomEuiPopOverCheckbox = styled(EuiPopOverCheckbox)`
+  border-right: none;
+  background: ${colors.light.pureWhite};
+  padding: 15px 10px !important;
+`;
+
 export const WorkspacePlannerHeader = observer(
   ({
     workspace_uuid,
@@ -335,7 +361,6 @@ export const WorkspacePlannerHeader = observer(
                     background: `${color.pureWhite}`,
                     borderRadius: '0px 0px 6px 6px',
                     maxWidth: '140px',
-                    minHeight: '160px',
                     marginTop: '0px',
                     marginLeft: '20px'
                   }}
@@ -345,42 +370,44 @@ export const WorkspacePlannerHeader = observer(
                   panelPaddingSize="none"
                   anchorPosition="downLeft"
                 >
-                  <div style={{ display: 'flex', flex: 'row' }}>
-                    <EuiPopOverCheckbox className="CheckboxOuter" color={color}>
-                      <EuiCheckboxGroup
-                        options={getFeatureOptions()}
-                        idToSelectedMap={bountyCardStore.selectedFeatures.reduce(
-                          (acc: { [key: string]: boolean }, featureId: string) => {
-                            acc[featureId] = true;
-                            return acc;
-                          },
-                          {}
-                        )}
-                        onChange={(id: string) => {
-                          bountyCardStore.toggleFeature(id);
-                          setFilterToggle(!filterToggle);
-                        }}
-                      />
-                      {bountyCardStore.selectedFeatures.length > 0 && (
-                        <div
-                          style={{
-                            padding: '8px 16px',
-                            borderTop: `1px solid ${color.grayish.G800}`
+                  <ScrollablePopoverContent>
+                    <div style={{ display: 'flex', flex: 'row' }}>
+                      <CustomEuiPopOverCheckbox className="CheckboxOuter" color={color}>
+                        <EuiCheckboxGroup
+                          options={getFeatureOptions()}
+                          idToSelectedMap={bountyCardStore.selectedFeatures.reduce(
+                            (acc: { [key: string]: boolean }, featureId: string) => {
+                              acc[featureId] = true;
+                              return acc;
+                            },
+                            {}
+                          )}
+                          onChange={(id: string) => {
+                            bountyCardStore.toggleFeature(id);
+                            setFilterToggle(!filterToggle);
                           }}
-                        >
-                          <ClearButton
-                            onClick={(e: React.MouseEvent): void => {
-                              e.stopPropagation();
-                              bountyCardStore.clearAllFilters();
-                              setFilterToggle(!filterToggle);
+                        />
+                        {bountyCardStore.selectedFeatures.length > 0 && (
+                          <div
+                            style={{
+                              padding: '8px 16px',
+                              borderTop: `1px solid ${color.grayish.G800}`
                             }}
                           >
-                            Clear All
-                          </ClearButton>
-                        </div>
-                      )}
-                    </EuiPopOverCheckbox>
-                  </div>
+                            <ClearButton
+                              onClick={(e: React.MouseEvent): void => {
+                                e.stopPropagation();
+                                bountyCardStore.clearAllFilters();
+                                setFilterToggle(!filterToggle);
+                              }}
+                            >
+                              Clear All
+                            </ClearButton>
+                          </div>
+                        )}
+                      </CustomEuiPopOverCheckbox>
+                    </div>
+                  </ScrollablePopoverContent>
                 </EuiPopover>
               </NewStatusContainer>
 
@@ -419,8 +446,7 @@ export const WorkspacePlannerHeader = observer(
                     boxShadow: `0px 1px 20px ${color.black90}`,
                     background: `${color.pureWhite}`,
                     borderRadius: '0px 0px 6px 6px',
-                    maxWidth: '140px',
-                    minHeight: '160px',
+                    maxWidth: '148px',
                     marginTop: '0px',
                     marginLeft: '20px'
                   }}
@@ -428,45 +454,47 @@ export const WorkspacePlannerHeader = observer(
                   panelPaddingSize="none"
                   anchorPosition="downLeft"
                 >
-                  <div style={{ display: 'flex', flex: 'row' }}>
-                    <EuiPopOverCheckbox className="CheckboxOuter" color={color}>
-                      <EuiCheckboxGroup
-                        options={bountyCardStore.availablePhases.map((phase: any) => ({
-                          label: phase.name,
-                          id: phase.uuid
-                        }))}
-                        idToSelectedMap={bountyCardStore.selectedPhases.reduce(
-                          (acc: { [key: string]: boolean }, phaseId: string) => {
-                            acc[phaseId] = true;
-                            return acc;
-                          },
-                          {}
-                        )}
-                        onChange={(id: string) => {
-                          bountyCardStore.togglePhase(id);
-                          setFilterToggle(!filterToggle);
-                        }}
-                      />
-                      {bountyCardStore.selectedPhases.length > 0 && (
-                        <div
-                          style={{
-                            padding: '8px 16px',
-                            borderTop: `1px solid ${color.grayish.G800}`
+                  <ScrollablePopoverContent>
+                    <div style={{ display: 'flex', flex: 'row' }}>
+                      <CustomEuiPopOverCheckbox className="CheckboxOuter" color={color}>
+                        <EuiCheckboxGroup
+                          options={bountyCardStore.availablePhases.map((phase: any) => ({
+                            label: phase.name,
+                            id: phase.uuid
+                          }))}
+                          idToSelectedMap={bountyCardStore.selectedPhases.reduce(
+                            (acc: { [key: string]: boolean }, phaseId: string) => {
+                              acc[phaseId] = true;
+                              return acc;
+                            },
+                            {}
+                          )}
+                          onChange={(id: string) => {
+                            bountyCardStore.togglePhase(id);
+                            setFilterToggle(!filterToggle);
                           }}
-                        >
-                          <ClearButton
-                            onClick={(e: React.MouseEvent): void => {
-                              e.stopPropagation();
-                              bountyCardStore.clearPhaseFilters();
-                              setFilterToggle(!filterToggle);
+                        />
+                        {bountyCardStore.selectedPhases.length > 0 && (
+                          <div
+                            style={{
+                              padding: '8px 16px',
+                              borderTop: `1px solid ${color.grayish.G800}`
                             }}
                           >
-                            Clear All
-                          </ClearButton>
-                        </div>
-                      )}
-                    </EuiPopOverCheckbox>
-                  </div>
+                            <ClearButton
+                              onClick={(e: React.MouseEvent): void => {
+                                e.stopPropagation();
+                                bountyCardStore.clearPhaseFilters();
+                                setFilterToggle(!filterToggle);
+                              }}
+                            >
+                              Clear All
+                            </ClearButton>
+                          </div>
+                        )}
+                      </CustomEuiPopOverCheckbox>
+                    </div>
+                  </ScrollablePopoverContent>
                 </EuiPopover>
               </NewStatusContainer>
 


### PR DESCRIPTION
## Problem:
The feature and phase filter popovers in the Workspace Planner header overflow beyond the screen boundaries, making lower options inaccessible to users. This creates a poor user experience as:

- Users cannot see or select options that extend beyond the viewport
- No scrolling mechanism exists to access hidden options

### Issue Demo:

https://www.loom.com/share/8f27fdad0e794ae797ba27c796d1e2cd

- `Feature filter:`

![bug](https://github.com/user-attachments/assets/68ec2fa1-c56d-42cb-8882-3bfd14d56be2)

- `Phase Filter:`
![phase-bug](https://github.com/user-attachments/assets/4fa4c4b8-57ec-4e22-b07e-d1d3e504c0cb)

### ***************************************** Fixed *****************************************

## Describe the Changes:
- Implemented scrollable filter popovers with custom styling to ensure all options are accessible within viewport boundaries

### Evidence:

https://www.loom.com/share/36dc199c258b4ebba75f4bb0cf50a343

![image](https://github.com/user-attachments/assets/22ce44a1-fd7f-4e49-a4ff-a9392cd9a431)

![image](https://github.com/user-attachments/assets/77d1f53e-657d-49fe-8fd4-89eb767bd8dd)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and demo of changes in my PR