### PR TITLE
using the env vars directly

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,15 +7,18 @@ import '@elastic/eui/dist/eui_theme_dark.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import { appEnv } from './config/env';
 
+//const options = {
+//  api_host: process.env.REACT_APP_PUBLIC_POSTHOG_HOST
+//};
 const options = {
-  api_host: process.env.REACT_APP_PUBLIC_POSTHOG_HOST
+  api_host: 'https://us.i.posthog.com'
 };
 
 if (appEnv.isTests) {
   ReactDOM.render(<App />, document.getElementById('root'));
 } else {
   ReactDOM.render(
-    <PostHogProvider apiKey={process.env.REACT_APP_PUBLIC_POSTHOG_KEY} options={options}>
+    <PostHogProvider apiKey={'phc_1UPR3wqvyvLllQJtpecsmaqEfKInrr0WDSPZf0RHODP'} options={options}>
       <App />
     </PostHogProvider>,
     document.getElementById('root')


### PR DESCRIPTION
## Describe your changes
It seems like when we deploy the env vars might not be used so I'm going to use them directly here, they're already exposed in index.html so it doesnt hurt to expose them here for now

I can make another change in the future to rotate and make them priavte to this repo