### PR TITLE
Add unit tests for BountyReviewStore.setLoading function

### DIFF
--- a/src/store/__test__/bountyReviewStore.spec.ts
+++ b/src/store/__test__/bountyReviewStore.spec.ts
@@ -1,0 +1,44 @@
+import { BountyReviewStore } from '../bountyReviewStore';
+
+describe('BountyReviewStore', () => {
+  let store: BountyReviewStore;
+
+  beforeEach(() => {
+    store = new BountyReviewStore();
+  });
+
+  describe('setLoading', () => {
+    it('should default to false', () => {
+      expect(store.loading).toEqual(false);
+    });
+
+    it('should be true after setting to true', () => {
+      store.setLoading(true);
+      expect(store.loading).toEqual(true);
+    });
+
+    it('should be true when already true and set to true again', () => {
+      store.setLoading(true);
+      store.setLoading(true);
+      expect(store.loading).toEqual(true);
+    });
+
+    it('should be false when true then set to false', () => {
+      store.setLoading(true);
+      store.setLoading(false);
+      expect(store.loading).toEqual(false);
+    });
+
+    it('should be false when already false and set to false again', () => {
+      store.setLoading(false);
+      store.setLoading(false);
+      expect(store.loading).toEqual(false);
+    });
+
+    it('should be false after rapid state change', () => {
+      for (let i = 0; i < 1000; i++) {
+        store.setLoading(i % 2 == 0);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Describe your changes
Bounty adding unit tests for setLoading
https://community.sphinx.chat/bounty/3514

My Sphinx pubkey
`032a5fd5dddd4429a1443c38c13893f96c61e8a9482fe69e96afea73741e0df0f3_034bcc332390470cc4f9ef7491af1da2ffceefccd39ceb6acd87c83920543013d7_529771090585976837`


## Issue ticket number and link

## Type of change

Please delete options that are not relevant.



## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ n/a ] I have tested on Chrome and Firefox
- [ n/a ] I have tested on a mobile device
- [ n/a ] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend