### PR TITLE
Optimize Docker build workflows in Github Actions

### DIFF
--- a/.github/workflows/build_on_master_merge.yml
+++ b/.github/workflows/build_on_master_merge.yml
@@ -18,41 +18,163 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-20.04
-    name: Build and push Tribes image (master)
+  build_amd64:
+    runs-on: ubuntu-24.04
+    name: Build Tribes AMD64 image (master)
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
-      - name: Check out from Git
-        uses: actions/checkout@v2
+      - name: Setup env
+        run: |
+          echo "PLATFORM=linux/amd64" | tee -a $GITHUB_ENV
       - name: Login to Docker Hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-      - name: Checkout project
-        uses: actions/checkout@v2
-      - name: Setup Docker buildx action
-        uses: crazy-max/ghaction-docker-buildx@v1
-        id: buildx
+        uses: docker/login-action@v3
         with:
-          buildx-version: latest
-          qemu-version: latest
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend
+      - name: Checkout project
+        uses: actions/checkout@v4
+      - name: Setup Docker buildx action
+        uses: docker/setup-buildx-action@v3
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache
         with:
-          path: /tmp/.buildx-cache
+          path: ${{ runner.temp }}/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Run Docker buildx
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ env.PLATFORM }}
+          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
+          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
+          build-args: |
+            REACT_APP_PUBLIC_POSTHOG_KEY=${{ secrets.REACT_APP_PUBLIC_POSTHOG_KEY }}
+            REACT_APP_PUBLIC_POSTHOG_HOST=${{ secrets.REACT_APP_PUBLIC_POSTHOG_HOST }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,"name=${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend",push-by-digest=true,push=true,name-canonical=true
+      - name: Export digest
         run: |
-          docker buildx build \
-          --cache-to "type=local,dest=/tmp/.buildx-cache" \
-          --build-arg REACT_APP_PUBLIC_POSTHOG_KEY=${{ secrets.REACT_APP_PUBLIC_POSTHOG_KEY }} \
-          --build-arg REACT_APP_PUBLIC_POSTHOG_HOST=${{ secrets.REACT_APP_PUBLIC_POSTHOG_HOST }} \
-          --platform linux/amd64,linux/arm/v7 \
-          --tag "${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend:master" \
-          --output "type=registry" ./
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-amd64
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf ${{ runner.temp }}/.buildx-cache
+          mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache
 
+  build_arm7:
+    runs-on: ubuntu-24.04-arm
+    name: Build Tribes ARMv7 image (master)
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+    steps:
+      - name: Setup env
+        run: |
+          echo "PLATFORM=linux/arm/v7" | tee -a $GITHUB_ENV
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend
+      - name: Checkout project
+        uses: actions/checkout@v4
+      - name: Setup Docker buildx action
+        uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: ${{ runner.temp }}/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Run Docker buildx
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ env.PLATFORM }}
+          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
+          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
+          build-args: |
+            REACT_APP_PUBLIC_POSTHOG_KEY=${{ secrets.REACT_APP_PUBLIC_POSTHOG_KEY }}
+            REACT_APP_PUBLIC_POSTHOG_HOST=${{ secrets.REACT_APP_PUBLIC_POSTHOG_HOST }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,"name=${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend",push-by-digest=true,push=true,name-canonical=true
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-arm7
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf ${{ runner.temp }}/.buildx-cache
+          mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache
 
-
+  create_and_push_manifest:
+    runs-on: ubuntu-24.04
+    needs:
+      - build_amd64
+      - build_arm7
+    steps:
+      - name: Download digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Setup Docker buildx action
+        uses: docker/setup-buildx-action@v3
+      - name: Docker image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend
+          tags: |
+            type=raw,value=master
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend@sha256:%s ' *)

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,56 +4,167 @@ env:
 
 on:
   push:
-    tags:
-      - '*'
+    tags: '*'
 
 jobs:
-  build:
-    runs-on: ubuntu-20.04
-    name: Build and push Tribes image 
+  build_amd64:
+    runs-on: ubuntu-24.04
+    name: Build Tribes AMD64 image 
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
-      - name: Check out from Git
-        uses: actions/checkout@v2
-      - name: Test env
-        run: echo "RELEASE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Test print env
+      - name: Setup env
         run: |
-          echo $RELEASE_TAG
-          echo ${{ env.RELEASE_TAG }}
+          echo "PLATFORM=linux/amd64" | tee -a $GITHUB_ENV
       - name: Login to Docker Hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-      - name: Checkout project
-        uses: actions/checkout@v2
-      - name: Setup Docker buildx action
-        uses: crazy-max/ghaction-docker-buildx@v1
-        id: buildx
+        uses: docker/login-action@v3
         with:
-          buildx-version: latest
-          qemu-version: latest
-      - name: Show available buildx platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend
+      - name: Checkout project
+        uses: actions/checkout@v4
+      - name: Setup Docker buildx action
+        uses: docker/setup-buildx-action@v3
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache
         with:
-          path: /tmp/.buildx-cache
+          path: ${{ runner.temp }}/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      - name: Test print env
-        run: |
-          echo $RELEASE_TAG
-          echo ${{ env.RELEASE_TAG }}
       - name: Run Docker buildx
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ env.PLATFORM }}
+          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
+          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
+          build-args: |
+            REACT_APP_PUBLIC_POSTHOG_KEY=${{ secrets.REACT_APP_PUBLIC_POSTHOG_KEY }}
+            REACT_APP_PUBLIC_POSTHOG_HOST=${{ secrets.REACT_APP_PUBLIC_POSTHOG_HOST }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,"name=${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend",push-by-digest=true,push=true,name-canonical=true
+      - name: Export digest
         run: |
-          docker buildx build \
-          --cache-to "type=local,dest=/tmp/.buildx-cache" \
-          --platform linux/amd64,linux/arm/v7 \
-          --build-arg REACT_APP_PUBLIC_POSTHOG_KEY=${{ secrets.REACT_APP_PUBLIC_POSTHOG_KEY }} \
-          --build-arg REACT_APP_PUBLIC_POSTHOG_HOST=${{ secrets.REACT_APP_PUBLIC_POSTHOG_HOST }} \
-          --tag "${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend:${{ env.RELEASE_TAG }}" \
-          --tag "${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend:latest" \
-          --output "type=registry" ./
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-amd64
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf ${{ runner.temp }}/.buildx-cache
+          mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache
 
+  build_arm7:
+    runs-on: ubuntu-24.04-arm
+    name: Build Tribes ARMv7 image
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+    steps:
+      - name: Setup env
+        run: |
+          echo "PLATFORM=linux/arm/v7" | tee -a $GITHUB_ENV
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend
+      - name: Checkout project
+        uses: actions/checkout@v4
+      - name: Setup Docker buildx action
+        uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: ${{ runner.temp }}/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Run Docker buildx
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ env.PLATFORM }}
+          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
+          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
+          build-args: |
+            REACT_APP_PUBLIC_POSTHOG_KEY=${{ secrets.REACT_APP_PUBLIC_POSTHOG_KEY }}
+            REACT_APP_PUBLIC_POSTHOG_HOST=${{ secrets.REACT_APP_PUBLIC_POSTHOG_HOST }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,"name=${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend",push-by-digest=true,push=true,name-canonical=true
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-arm7
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf ${{ runner.temp }}/.buildx-cache
+          mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache
+
+  create_and_push_manifest:
+    runs-on: ubuntu-24.04
+    needs:
+      - build_amd64
+      - build_arm7
+    steps:
+      - name: Download digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Setup Docker buildx action
+        uses: docker/setup-buildx-action@v3
+      - name: Docker image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{raw}}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ secrets.DOCKER_HUB_USER }}/sphinx-tribes-frontend@sha256:%s ' *)


### PR DESCRIPTION
## Describe your changes
The critical change here is pushing the ARMv7 build off to an ARM64 runner. 

Running the ARMv7 build on x86_64/amd64 architecture runners requires QEMU emulation of ARM64 which incurs a dramatic reduction in performance.

I've got the build down to about 4-5 minutes total from about 20 minutes.

Here are my builds on my forked repo
https://github.com/seankibler/sphinx-tribes-frontend/actions/workflows/docker-build.yml

And the resulting images in Docker Hub
https://hub.docker.com/r/skibler/sphinx-tribes-frontend/tags

The workflow now starts two jobs on two runners in parallel; one building amd64 and one building armv7, a third job waits for both of the image build jobs to complete, it then assembles them both into a manifest and pushes that manifest to Docker Hub.

Some of the actions have been updated as many were using deprecated versions or unmaintained.

- Upgraded deprecated actions/checkout/v2 to actions/checkout/v4
- Upgraded deprecated actions/cache/v2 to actions/cache/v4
- Replaced unmaintained crazy-max/ghaction-docker-buildx@v1 to 

All prior secret names have been preserved, no changes to secret names are required. This should be a drop-in replacement.

Fair warning, the ARM64 runners are in preview and are subject to change.
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

## Issue ticket number and link

## Type of change
CI / CD change only
