### PR TITLE
Update Draft Ticket View with Feature and Phase Selection

### DIFF
--- a/src/components/common/TicketEditor/WorkspaceTicketEditor.tsx
+++ b/src/components/common/TicketEditor/WorkspaceTicketEditor.tsx
@@ -40,6 +40,7 @@ interface TicketEditorProps {
   dragHandleProps?: Record<string, any>;
   swwfLink?: string;
   getPhaseTickets: () => Promise<Ticket[] | undefined>;
+  onSave?: (ticket: Ticket) => void;
 }
 
 const SwitcherContainer = styled.div`
@@ -126,7 +127,7 @@ const EditorWrapper = styled.div`
 `;
 
 const WorkspaceTicketEditor = observer(
-  ({ ticketData, websocketSessionId, dragHandleProps, swwfLink }: TicketEditorProps) => {
+  ({ ticketData, websocketSessionId, dragHandleProps, swwfLink, onSave }: TicketEditorProps) => {
     const [toasts, setToasts] = useState<Toast[]>([]);
     const [versions, setVersions] = useState<number[]>([]);
     const latestTicket = workspaceTicketStore.getLatestVersionFromGroup(
@@ -245,6 +246,10 @@ const WorkspaceTicketEditor = observer(
               updatedTicket.uuid = updatedTicket.UUID;
             }
             workspaceTicketStore.addTicket(updatedTicket);
+
+            if (updatedTicket.version === ticketData.version + 1) {
+              onSave?.(updatedTicket);
+            }
           }
         }
 

--- a/src/pages/tickets/style.ts
+++ b/src/pages/tickets/style.ts
@@ -538,7 +538,6 @@ export const StyledLink = styled.a`
   color: #648dff;
   text-decoration: none;
   cursor: pointer;
-  margin-left: 20px;
 
   &:hover {
     text-decoration: underline;

--- a/src/people/widgetViews/workspace/WorkspaceTicketView.tsx
+++ b/src/people/widgetViews/workspace/WorkspaceTicketView.tsx
@@ -362,25 +362,25 @@ const WorkspaceTicketView: React.FC = observer(() => {
         </SelectWrapper>
 
         <SelectWrapper>
-            <StyledSelect
-              value={currentTicket?.phase_uuid || ''}
-              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                handlePhaseChange(e.target.value || undefined)
-              }
-              disabled={isLoadingPhases || !currentTicket?.feature_uuid}
-            >
-              <option value="">Select Phase</option>
-              {phases.map((phase: Phase) => (
-                <option key={phase.uuid} value={phase.uuid}>
-                  {phase.name}
-                </option>
-              ))}
-            </StyledSelect>
-            {currentTicket?.feature_uuid && currentTicket?.phase_uuid && (
-              <LabelValue style={{ marginTop: '10px' }}>
-                <StyledLink onClick={handleLinkClick}>[Phase Planner]</StyledLink>
-              </LabelValue>
-            )}
+          <StyledSelect
+            value={currentTicket?.phase_uuid || ''}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+              handlePhaseChange(e.target.value || undefined)
+            }
+            disabled={isLoadingPhases || !currentTicket?.feature_uuid}
+          >
+            <option value="">Select Phase</option>
+            {phases.map((phase: Phase) => (
+              <option key={phase.uuid} value={phase.uuid}>
+                {phase.name}
+              </option>
+            ))}
+          </StyledSelect>
+          {currentTicket?.feature_uuid && currentTicket?.phase_uuid && (
+            <LabelValue style={{ marginTop: '10px' }}>
+              <StyledLink onClick={handleLinkClick}>[Phase Planner]</StyledLink>
+            </LabelValue>
+          )}
         </SelectWrapper>
         <WorkspaceTicketEditor
           ticketData={currentTicket}

--- a/src/people/widgetViews/workspace/WorkspaceTicketView.tsx
+++ b/src/people/widgetViews/workspace/WorkspaceTicketView.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/typedef */
 import React, { useCallback, useEffect, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useParams, useHistory } from 'react-router-dom';
@@ -8,14 +7,14 @@ import MaterialIcon from '@material/react-material-icon';
 import { createSocketInstance, SOCKET_MSG } from 'config/socket';
 import WorkspaceTicketEditor from 'components/common/TicketEditor/WorkspaceTicketEditor';
 import { workspaceTicketStore } from '../../../store/workspace-ticket';
-import { Feature, TicketMessage } from '../../../store/interface';
+import { Feature, Ticket, TicketMessage } from '../../../store/interface';
 import { FeatureBody, FeatureDataWrap, LabelValue, StyledLink } from '../../../pages/tickets/style';
 import {
   FeatureHeadWrap,
   FeatureHeadNameWrap,
   WorkspaceName,
-  SelectWrapper,
-  StyledSelect
+  StyledSelect,
+  SelectWrapper
 } from './style';
 import { Phase } from './interface.ts';
 
@@ -23,15 +22,15 @@ const WorkspaceTicketView: React.FC = observer(() => {
   const { workspaceId, ticketId } = useParams<{ workspaceId: string; ticketId: string }>();
   const [websocketSessionId, setWebsocketSessionId] = useState<string>('');
   const [swwfLinks, setSwwfLinks] = useState<Record<string, string>>({});
-  const [featureData, setFeatureData] = useState<Feature | null>(null);
-  const [phaseData, setPhaseData] = useState<Phase | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const { main } = useStores();
   const history = useHistory();
   const [currentTicketId, setCurrentTicketId] = useState<string>(ticketId);
-  const [availableFeatures, setAvailableFeatures] = useState<Feature[]>([]);
-  const [availablePhases, setAvailablePhases] = useState<Phase[]>([]);
-  const [selectedFeature, setSelectedFeature] = useState<Feature | null>(null);
+  const [features, setFeatures] = useState<Feature[]>([]);
+  const [phases, setPhases] = useState<Phase[]>([]);
+
+  const [isLoadingFeatures, setIsLoadingFeatures] = useState(false);
+  const [isLoadingPhases, setIsLoadingPhases] = useState(false);
 
   useEffect(() => {
     const socket = createSocketInstance();
@@ -181,8 +180,8 @@ const WorkspaceTicketView: React.FC = observer(() => {
         const feature = await getFeatureData();
         const phase = await getPhaseData();
         if (feature && phase) {
-          setFeatureData(feature);
-          setPhaseData(phase);
+          // setFeatureData(feature);
+          // setPhaseData(phase);
         }
       } catch (error) {
         console.error('Error fetching data:', error);
@@ -199,72 +198,83 @@ const WorkspaceTicketView: React.FC = observer(() => {
     );
   };
 
-  // Fetch available features when component mounts
   useEffect(() => {
-    const fetchFeatures = async () => {
+    const loadFeatures = async () => {
+      setIsLoadingFeatures(true);
       try {
-        const features = await main.getWorkspaceFeatures(workspaceId, {});
-        setAvailableFeatures(features);
+        const workspaceFeatures = await main.getWorkspaceFeatures(workspaceId, {});
+        setFeatures(workspaceFeatures);
       } catch (error) {
-        console.error('Error fetching features:', error);
+        console.error('Error loading features:', error);
+      } finally {
+        setIsLoadingFeatures(false);
       }
     };
-    fetchFeatures();
-  }, [main]);
+    loadFeatures();
+  }, [workspaceId, main]);
 
-  // Fetch phases when feature is selected
   useEffect(() => {
-    const fetchPhases = async () => {
-      if (selectedFeature?.uuid) {
+    const loadPhases = async () => {
+      if (!currentTicket?.feature_uuid) {
+        setPhases([]);
+        return;
+      }
+
+      setIsLoadingPhases(true);
+      try {
+        const featurePhases = await main.getFeaturePhases(currentTicket.feature_uuid);
+        setPhases(featurePhases);
+      } catch (error) {
+        console.error('Error loading phases:', error);
+      } finally {
+        setIsLoadingPhases(false);
+      }
+    };
+    loadPhases();
+  }, [currentTicket?.feature_uuid, main]);
+
+  const handleFeatureChange = async (featureUuid: string | undefined) => {
+    if (!currentTicket) return;
+
+    const updatedTicket: Partial<Ticket> = {
+      ...currentTicket,
+      feature_uuid: featureUuid,
+      phase_uuid: undefined
+    };
+
+    workspaceTicketStore.updateTicket(currentTicket.uuid, updatedTicket);
+    setCurrentTicketId(currentTicket.uuid);
+  };
+
+  const handlePhaseChange = async (phaseUuid: string | undefined) => {
+    if (!currentTicket) return;
+
+    const updatedTicket: Partial<Ticket> = {
+      ...currentTicket,
+      phase_uuid: phaseUuid
+    };
+
+    workspaceTicketStore.updateTicket(currentTicket.uuid, updatedTicket);
+    setCurrentTicketId(currentTicket.uuid);
+  };
+
+  useEffect(() => {
+    const currentTicket = workspaceTicketStore.getTicket(currentTicketId);
+    if (currentTicket?.feature_uuid) {
+      const loadPhases = async () => {
+        setIsLoadingPhases(true);
         try {
-          const phases = await main.getFeaturePhases(selectedFeature.uuid);
-          setAvailablePhases(phases);
+          const featurePhases = await main.getFeaturePhases(currentTicket.feature_uuid as string);
+          setPhases(featurePhases);
         } catch (error) {
-          console.error('Error fetching phases:', error);
+          console.error('Error loading phases:', error);
+        } finally {
+          setIsLoadingPhases(false);
         }
-      }
-    };
-    fetchPhases();
-  }, [selectedFeature?.uuid, main]);
-
-  const handleFeatureChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const featureUuid = e.target.value;
-    const selectedFeature = availableFeatures.find((f) => f.uuid === featureUuid);
-
-    if (selectedFeature) {
-      setSelectedFeature(selectedFeature);
-      setFeatureData(selectedFeature);
-      // Clear phase data when feature changes
-      setPhaseData(null);
-      setAvailablePhases([]);
+      };
+      loadPhases();
     }
-  };
-
-  const handlePhaseChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const phaseUuid = e.target.value;
-    const selectedPhase = availablePhases.find((p) => p.uuid === phaseUuid);
-    if (selectedPhase) {
-      setPhaseData(selectedPhase);
-    }
-  };
-
-  const handleSave = async () => {
-    if (currentTicket) {
-      try {
-        await main.createUpdateTicket({
-          metadata: { source: 'workspace', id: currentTicket.uuid },
-          ticket: {
-            ...currentTicket,
-            feature_uuid: featureData?.uuid || '',
-            phase_uuid: phaseData?.uuid || ''
-          }
-        });
-        // Show success notification or refresh data
-      } catch (error) {
-        console.error('Error updating ticket:', error);
-      }
-    }
-  };
+  }, [currentTicketId, main]);
 
   if (isLoading) {
     return (
@@ -335,33 +345,42 @@ const WorkspaceTicketView: React.FC = observer(() => {
       </FeatureHeadWrap>
       <FeatureDataWrap>
         <SelectWrapper>
-          <StyledSelect value={selectedFeature?.uuid || ''} onChange={handleFeatureChange}>
+          <StyledSelect
+            value={currentTicket?.feature_uuid || ''}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+              handleFeatureChange(e.target.value || undefined)
+            }
+            disabled={isLoadingFeatures}
+          >
             <option value="">Select Feature</option>
-            {availableFeatures.map((f) => (
-              <option key={f.uuid} value={f.uuid}>
-                {f.name}
+            {features.map((feature: Feature) => (
+              <option key={feature.uuid} value={feature.uuid}>
+                {feature.name}
               </option>
             ))}
           </StyledSelect>
         </SelectWrapper>
-        <SelectWrapper style={{ marginBottom: '10px' }}>
-          <StyledSelect
-            value={phaseData?.uuid || ''}
-            onChange={handlePhaseChange}
-            disabled={!selectedFeature}
-          >
-            <option value="">Select Phase</option>
-            {availablePhases.map((p) => (
-              <option key={p.uuid} value={p.uuid}>
-                {p.name}
-              </option>
-            ))}
-          </StyledSelect>
-          {selectedFeature && phaseData && (
-            <LabelValue style={{ marginTop: '10px' }}>
-              <StyledLink onClick={handleLinkClick}>[Phase Planner]</StyledLink>
-            </LabelValue>
-          )}
+
+        <SelectWrapper>
+            <StyledSelect
+              value={currentTicket?.phase_uuid || ''}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                handlePhaseChange(e.target.value || undefined)
+              }
+              disabled={isLoadingPhases || !currentTicket?.feature_uuid}
+            >
+              <option value="">Select Phase</option>
+              {phases.map((phase: Phase) => (
+                <option key={phase.uuid} value={phase.uuid}>
+                  {phase.name}
+                </option>
+              ))}
+            </StyledSelect>
+            {currentTicket?.feature_uuid && currentTicket?.phase_uuid && (
+              <LabelValue style={{ marginTop: '10px' }}>
+                <StyledLink onClick={handleLinkClick}>[Phase Planner]</StyledLink>
+              </LabelValue>
+            )}
         </SelectWrapper>
         <WorkspaceTicketEditor
           ticketData={currentTicket}
@@ -371,7 +390,10 @@ const WorkspaceTicketView: React.FC = observer(() => {
           hasInteractiveChildren={false}
           swwfLink={swwfLinks[currentTicket.uuid]}
           getPhaseTickets={getTickets}
-          onSave={handleSave}
+          onSave={(updatedTicket: Ticket) => {
+            workspaceTicketStore.updateTicket(updatedTicket.uuid, updatedTicket);
+            setCurrentTicketId(updatedTicket.uuid);
+          }}
         />
       </FeatureDataWrap>
     </FeatureBody>

--- a/src/people/widgetViews/workspace/style.ts
+++ b/src/people/widgetViews/workspace/style.ts
@@ -1863,3 +1863,56 @@ export const ProofActionButton = styled.button<ButtonProps>`
     }
   }
 `;
+
+export const SelectWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 300px;
+  margin-bottom: 16px;
+`;
+
+export const StyledSelect = styled.select`
+  width: 100%;
+  padding: 12px 40px 12px 16px;
+  font-size: 16px;
+  border: 2px solid #e5e7eb;
+  border-radius: 8px;
+  background-color: #ffffff;
+  color: #1f2937;
+  appearance: none;
+  cursor: pointer;
+  transition: 0.2s ease all;
+
+  &:hover {
+    border-color: #3b82f6;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
+
+  &:disabled {
+    background-color: #f3f4f6;
+    border-color: #d1d5db;
+    color: #9ca3af;
+    cursor: not-allowed;
+  }
+
+  option {
+    padding: 12px;
+  }
+
+  /* Style for the placeholder option */
+  option:first-child {
+    color: #6b7280;
+  }
+
+  /* Change color when an actual option is selected */
+  &:not(:invalid) {
+    color: #1f2937;
+  }
+`;


### PR DESCRIPTION
## Issue ticket number and link
https://community.sphinx.chat/bounty/3678

## Describe your changes

This PR introduces dropdown functionality for selecting Features and Phases in the Workspace Ticket View, replacing the previous static display. The changes provide a more intuitive and flexible way to manage feature and phase associations for tickets.

**Key Changes:**
1. **Dropdown Implementation:**
   - Replaced static feature and phase display with interactive dropdowns
   - Dropdowns are populated with available features and phases from the workspace
   - Added proper styling using styled components for consistent UI
2. **Default Value Handling:**
   - If a feature/phase is already set, the dropdowns default to showing the current Feature Name and Phase Name
   - Maintains existing associations while allowing for updates
3. **Update Functionality:**
   - Selecting a new feature or phase updates the corresponding values when "Save" is clicked
   - Changes are persisted through the existing save mechanism
4. **Blank Selection Support:**
   - Added ability to select a blank option in both dropdowns
   - Selecting blank removes the feature/phase association
   - Ensures the component properly handles and displays tickets with no feature/phase set
5. **UI/UX Improvements:**
   - Added proper labels and spacing for better usability
   - Implemented disabled state for phase dropdown when no feature is selected
   - Maintained the Phase Planner link functionality for associated features/phases
**Testing:**
- Verified dropdowns display correct default values when feature/phase is set
- Confirmed updates are properly saved when selecting new values
- Tested blank selection functionality
- Verified component behavior with no feature/phase set
- Checked disabled state of phase dropdown when no feature is selected

**loom**
https://www.loom.com/share/0b3a0bb8d110479d9b95cda8caed8b50?sid=4eabafb6-7559-4f51-a3d4-fd7fb43a80eb

**Screenshots:**
![Screenshot from 2025-02-13 18-32-46](https://github.com/user-attachments/assets/c26a2090-7a94-49ba-baa4-fdc4c6b13286)
![Screenshot from 2025-02-13 18-32-54](https://github.com/user-attachments/assets/3feca336-a3fd-4ec8-aea3-24b2b1dfe4e4)
![Screenshot from 2025-02-13 18-33-02](https://github.com/user-attachments/assets/001d3fad-22e6-48f1-8f44-8a1cb1c97f97)