### PR TITLE
Revert "Feature: Add Phase Design Field to Phase Planner View"

### DIFF
--- a/src/people/widgetViews/PhasePlannerView.tsx
+++ b/src/people/widgetViews/PhasePlannerView.tsx
@@ -61,19 +61,15 @@ const PhasePlannerView: React.FC = observer(() => {
   const [purpose, setPurpose] = useState<string>(phaseData?.phase_purpose || '');
   const [outcome, setOutcome] = useState<string>(phaseData?.phase_outcome || '');
   const [scope, setScope] = useState<string>(phaseData?.phase_scope || '');
-  const [design, setDesign] = useState<string>(phaseData?.phase_design || '');
   const [editPurpose, setEditPurpose] = useState<boolean>(false);
   const [editOutcome, setEditOutcome] = useState<boolean>(false);
   const [editScope, setEditScope] = useState<boolean>(false);
-  const [editDesign, setEditDesign] = useState<boolean>(false);
   const [displayPurpose, setDisplayPurpose] = useState<boolean>(false);
   const [displayOutcome, setDisplayOutcome] = useState<boolean>(false);
   const [displayScope, setDisplayScope] = useState<boolean>(false);
-  const [displayDesign, setDisplayDesign] = useState<boolean>(false);
   const [purposePreviewMode, setPurposePreviewMode] = useState<'preview' | 'edit'>('edit');
   const [outcomePreviewMode, setOutcomePreviewMode] = useState<'preview' | 'edit'>('edit');
   const [scopePreviewMode, setScopePreviewMode] = useState<'preview' | 'edit'>('edit');
-  const [designPreviewMode, setDesignPreviewMode] = useState<'preview' | 'edit'>('edit');
   const [toasts, setToasts] = useState<Toast[]>([]);
   const { main } = useStores();
   const history = useHistory();
@@ -212,11 +208,6 @@ const PhasePlannerView: React.FC = observer(() => {
     setDisplayScope(false);
   };
 
-  const editDesignActions = () => {
-    setEditDesign(!editDesign);
-    setDisplayDesign(false);
-  };
-
   const submitPurpose = async () => {
     if (!phaseData) return;
     try {
@@ -316,39 +307,6 @@ const PhasePlannerView: React.FC = observer(() => {
     }
   };
 
-  const submitDesign = async () => {
-    if (!phaseData) return;
-    try {
-      const updatedPhase = await main.createOrUpdatePhase({
-        ...phaseData,
-        phase_design: design
-      });
-      if (updatedPhase) {
-        setPhaseData(updatedPhase);
-        setDesign(updatedPhase.phase_design || '');
-        setEditDesign(false);
-        setToasts([
-          {
-            id: `${Date.now()}-design-success`,
-            title: 'Success',
-            color: 'success',
-            text: 'Design updated successfully!'
-          }
-        ]);
-      }
-    } catch (error) {
-      console.error('Error updating phase design:', error);
-      setToasts([
-        {
-          id: `${Date.now()}-design-error`,
-          title: 'Error',
-          color: 'danger',
-          text: 'Failed to update design'
-        }
-      ]);
-    }
-  };
-
   const getFeatureData = useCallback(async () => {
     if (!feature_uuid) return;
     const data = await main.getFeaturesByUuid(feature_uuid);
@@ -406,7 +364,6 @@ const PhasePlannerView: React.FC = observer(() => {
           setPurpose(phase.phase_purpose || '');
           setOutcome(phase.phase_outcome || '');
           setScope(phase.phase_scope || '');
-          setDesign(phase.phase_design || '');
         }
       } catch (error) {
         console.error('Error fetching data:', error);
@@ -696,57 +653,6 @@ const PhasePlannerView: React.FC = observer(() => {
                       color="primary"
                       onClick={submitScope}
                       data-testid="scope-update-btn"
-                    >
-                      Update
-                    </ActionButton>
-                  </ButtonWrap>
-                )}
-              </Data>
-            </FieldWrap>
-
-            <FieldWrap>
-              <Label>Design</Label>
-              <Data>
-                <OptionsWrap>
-                  <MaterialIcon
-                    icon={'more_horiz'}
-                    className="MaterialIcon"
-                    onClick={() => setDisplayDesign(!displayDesign)}
-                    data-testid="design-option-btn"
-                  />
-                  {displayDesign && (
-                    <EditPopover>
-                      <EditPopoverTail />
-                      <EditPopoverContent onClick={editDesignActions}>
-                        <MaterialIcon icon="edit" style={{ fontSize: '20px', marginTop: '2px' }} />
-                        <EditPopoverText data-testid="design-edit-btn">Edit</EditPopoverText>
-                      </EditPopoverContent>
-                    </EditPopover>
-                  )}
-                </OptionsWrap>
-                <EditableField
-                  value={design ?? phaseData?.phase_design ?? ''}
-                  setValue={setDesign}
-                  isEditing={editDesign}
-                  previewMode={designPreviewMode}
-                  setPreviewMode={setDesignPreviewMode}
-                  placeholder="Design"
-                  dataTestIdPrefix="design"
-                  workspaceUUID={featureData?.workspace_uuid}
-                />
-                {editDesign && (
-                  <ButtonWrap>
-                    <ActionButton
-                      onClick={() => setEditDesign(!editDesign)}
-                      data-testid="design-cancel-btn"
-                      color="cancel"
-                    >
-                      Cancel
-                    </ActionButton>
-                    <ActionButton
-                      color="primary"
-                      onClick={submitDesign}
-                      data-testid="design-update-btn"
                     >
                       Update
                     </ActionButton>

--- a/src/people/widgetViews/workspace/interface.ts
+++ b/src/people/widgetViews/workspace/interface.ts
@@ -97,7 +97,6 @@ export interface Phase {
   phase_purpose?: string;
   phase_outcome?: string;
   phase_scope?: string;
-  phase_design?: string;
 }
 
 export type PhaseOperationType = 'create' | 'edit' | 'delete';


### PR DESCRIPTION
Reverts stakwork/sphinx-tribes-frontend#1089

TypeScript type error:

typescriptCopyTS2739: Type '{ ... }' is missing the following properties from type 'EditableFieldProps': onCancel, onUpdate
This means that the EditableField component on line 727 requires two props that weren't provided:

onCancel: A callback function
onUpdate: A callback function

To fix this, you'll need to add these required props to the EditableField component where it's being used:
typescriptCopy<EditableField
  value={design ?? phaseData?.phase_design ?? ''}
  setValue={setDesign}
  isEditing={editDesign}
  onCancel={() => {/* Add your cancel logic here */}}
  onUpdate={(newValue) => {/* Add your update logic here */}}
  // ... other props
/>

----

This is causing merge failures. 