### PR TITLE
Fix WebSocket connection in GitHub Codespaces by enforcing WSS protocol

### DIFF
--- a/cypress/e2e/04_createWorkspaceBounty.cy.ts
+++ b/cypress/e2e/04_createWorkspaceBounty.cy.ts
@@ -30,7 +30,7 @@ describe('User creates a bounty attached to a workspace', () => {
 
   it('should verify the bounty tile has the org label and is clickable', () => {
     cy.create_bounty(bounty);
-    cy.wait(1000);
+    cy.wait(2000);
 
     cy.contains(bounty.title);
     cy.wait(1000);

--- a/src/config/socket.ts
+++ b/src/config/socket.ts
@@ -1,10 +1,17 @@
 import { v4 as uuidv4 } from 'uuid';
 import { getHost } from './host';
 
-export const URL =
-  process.env.NODE_ENV !== 'development'
+export const URL = (() => {
+  const isCodespaces = window.location.hostname.includes('app.github.dev');
+
+  if (isCodespaces) {
+    return `wss://${getHost()}/websocket`;
+  }
+
+  return process.env.NODE_ENV !== 'development'
     ? `wss://${getHost()}/websocket`
     : `ws://${getHost()}/websocket`;
+})();
 
 export const SOCKET_MSG = {
   keysend_error: 'keysend_error',


### PR DESCRIPTION
## Describe your changes

- Adds detection for GitHub Codespaces environment by checking the hostname
- Forces the use of secure WebSocket protocol ('wss://') when running in Codespaces
- Maintains the original behavior for other environments

The error occurred because browsers prevent establishing insecure WebSocket connections ('ws://') when the page is loaded over HTTPS, which is the case in GitHub Codespaces. Using 'wss://' ensures a secure connection that's compatible with HTTPS pages.


## Issue ticket number and link

## Type of change

![image](https://github.com/user-attachments/assets/461a6652-bbd3-41fa-abb2-b7c51471973e)

![image](https://github.com/user-attachments/assets/7eacd12a-2dd2-4b35-b597-e2138aa19057)

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device
- [ ] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend