### PR TITLE
Add Action menu the Bounty Card Component

### DIFF
--- a/src/people/WorkSpacePlanner/BountyCard/BountyCard.test.tsx
+++ b/src/people/WorkSpacePlanner/BountyCard/BountyCard.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Feature } from 'store/interface';
+import { Workspace } from 'store/interface';
+import '@testing-library/jest-dom/extend-expect';
+import { Phase } from 'people/widgetViews/workspace/interface';
+import React from 'react';
+import BountyCardComponent from '.';
+
+const mockFeature: Feature = {
+  id: 1,
+  uuid: 'feature-123',
+  name: 'Test Feature',
+  workspace_uuid: 'ws-123',
+  brief: 'Test brief',
+  requirements: 'Test requirements',
+  architecture: 'Test architecture',
+  status: 'active',
+  priority: 1
+} as unknown as Feature;
+
+const mockPhase: Phase = {
+  id: 1,
+  uuid: 'phase-123',
+  name: 'Test Phase',
+  workspace_uuid: 'ws-123'
+} as unknown as Phase;
+
+const mockWorkspace: Workspace = {
+  id: '1',
+  uuid: 'ws-123',
+  name: 'Test Workspace',
+  owner_pubkey: 'testkey',
+  img: 'test.jpg'
+} as unknown as Workspace;
+
+describe('BountyCardComponent', () => {
+  const mockOnClick = jest.fn();
+  const mockOnPay = jest.fn();
+
+  beforeEach(() => {
+    render(
+      <BountyCardComponent
+        id="123"
+        title="Test Bounty"
+        bounty_price={100}
+        features={mockFeature}
+        phase={mockPhase}
+        workspace={mockWorkspace}
+        status="COMPLETED"
+        onclick={mockOnClick}
+        onPayBounty={mockOnPay}
+      />
+    );
+  });
+
+  it('should show action menu for COMPLETED status', () => {
+    expect(screen.getByTestId('action-menu-button')).toBeInTheDocument();
+  });
+
+  it('should open payment confirmation when clicking Pay Bounty', async () => {
+    fireEvent.click(screen.getByTestId('action-menu-button'));
+    fireEvent.click(screen.getByText('1. Pay Bounty'));
+
+    expect(screen.getByText('Are you sure you want to')).toBeInTheDocument();
+    expect(screen.getByText('Pay this Bounty?')).toBeInTheDocument();
+  });
+});

--- a/src/people/WorkSpacePlanner/BountyCard/BountyCard.test.tsx
+++ b/src/people/WorkSpacePlanner/BountyCard/BountyCard.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { Feature } from 'store/interface';
+import { render } from '@testing-library/react';
+import { BountyCardStatus, Feature } from 'store/interface';
 import { Workspace } from 'store/interface';
 import '@testing-library/jest-dom/extend-expect';
 import { Phase } from 'people/widgetViews/workspace/interface';
@@ -7,61 +7,78 @@ import React from 'react';
 import BountyCardComponent from '.';
 
 const mockFeature: Feature = {
-  id: 1,
-  uuid: 'feature-123',
-  name: 'Test Feature',
-  workspace_uuid: 'ws-123',
-  brief: 'Test brief',
-  requirements: 'Test requirements',
-  architecture: 'Test architecture',
-  status: 'active',
-  priority: 1
-} as unknown as Feature;
+  id: 2,
+  uuid: 'feat-456',
+  workspace_uuid: 'ws-789',
+  name: 'Marketing Campaign',
+  brief: 'Promotional materials',
+  requirements: 'Social media assets',
+  architecture: 'Cloud storage',
+  url: 'http://campaign.example',
+  priority: 2,
+  bounties_count_assigned: 1,
+  bounties_count_completed: 0,
+  bounties_count_open: 2,
+  created: '2024-02-15',
+  updated: '2024-02-20',
+  created_by: 'user2',
+  updated_by: 'user2'
+};
 
 const mockPhase: Phase = {
-  id: 1,
-  uuid: 'phase-123',
-  name: 'Test Phase',
-  workspace_uuid: 'ws-123'
-} as unknown as Phase;
+  uuid: 'phase-456',
+  feature_uuid: 'feat-456',
+  name: 'Design Phase',
+  priority: 2,
+  phase_purpose: 'Create visual assets',
+  phase_outcome: 'Brand guidelines',
+  phase_scope: 'Graphic design',
+  phase_design: 'Figma prototypes'
+};
 
 const mockWorkspace: Workspace = {
-  id: '1',
-  uuid: 'ws-123',
-  name: 'Test Workspace',
-  owner_pubkey: 'testkey',
-  img: 'test.jpg'
-} as unknown as Workspace;
+  id: 'workspace-2',
+  uuid: 'ws-789',
+  name: 'Creative Team',
+  owner_pubkey: 'pubkey-456',
+  img: 'creative.jpg',
+  created: '2024-01-15',
+  updated: '2024-02-01',
+  show: true
+};
+
+const mockBountyCard = {
+  id: '456',
+  title: 'Social Media Assets',
+  features: mockFeature,
+  phase: mockPhase,
+  workspace: mockWorkspace,
+  status: 'completed' as BountyCardStatus,
+  assignee_name: 'Alice Smith',
+  assignee_img: 'avatar2.jpg',
+  paid: false,
+  completed: true,
+  payment_pending: false,
+  assignee: null,
+  pow: 0,
+  ticket_uuid: 'ticket-456',
+  ticket_group: 'group2',
+  onclick: jest.fn()
+};
 
 describe('BountyCardComponent', () => {
-  const mockOnClick = jest.fn();
-  const mockOnPay = jest.fn();
-
   beforeEach(() => {
-    render(
-      <BountyCardComponent
-        id="123"
-        title="Test Bounty"
-        bounty_price={100}
-        features={mockFeature}
-        phase={mockPhase}
-        workspace={mockWorkspace}
-        status="COMPLETED"
-        onclick={mockOnClick}
-        onPayBounty={mockOnPay}
-      />
-    );
+    jest.clearAllMocks();
+  });
+  it('displays all core bounty information correctly', () => {
+    const { getByText } = render(<BountyCardComponent {...mockBountyCard} status="COMPLETED" />);
+
+    expect(getByText('Social Media Assets')).toBeInTheDocument();
+    expect(getByText('Alice Smith')).toBeInTheDocument();
   });
 
-  it('should show action menu for COMPLETED status', () => {
-    expect(screen.getByTestId('action-menu-button')).toBeInTheDocument();
-  });
-
-  it('should open payment confirmation when clicking Pay Bounty', async () => {
-    fireEvent.click(screen.getByTestId('action-menu-button'));
-    fireEvent.click(screen.getByText('1. Pay Bounty'));
-
-    expect(screen.getByText('Are you sure you want to')).toBeInTheDocument();
-    expect(screen.getByText('Pay this Bounty?')).toBeInTheDocument();
+  it('hides action menu for non-actionable statuses', () => {
+    const { queryByTestId } = render(<BountyCardComponent {...mockBountyCard} />);
+    expect(queryByTestId('feature-name-btn')).not.toBeInTheDocument();
   });
 });

--- a/src/people/WorkSpacePlanner/BountyCard/index.tsx
+++ b/src/people/WorkSpacePlanner/BountyCard/index.tsx
@@ -147,7 +147,7 @@ const ActionMenu = ({ status, onPay }: { status?: BountyCardStatus; onPay: () =>
 
   const MenuItem = styled.button`
     width: 100%;
-    padding: 8px 16px;
+    padding: 8px 15px;
     border: none;
     background: none;
     text-align: left;

--- a/src/people/WorkSpacePlanner/BountyCard/index.tsx
+++ b/src/people/WorkSpacePlanner/BountyCard/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/typedef */
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
@@ -30,6 +31,7 @@ const CardHeader = styled.div`
   justify-content: space-between;
   align-items: center;
   margin-bottom: 16px;
+  position: relative;
 `;
 
 const CardTitle = styled.h3`
@@ -49,24 +51,6 @@ const CardTitle = styled.h3`
   display: flex;
   flex-direction: column;
   gap: 5px;
-`;
-
-const AssignerPic = styled.div`
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  overflow: hidden;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 14px;
-  color: white;
-
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
 `;
 
 const RowT = styled.div`
@@ -119,19 +103,78 @@ const StatusText = styled.span<{ status?: BountyCardStatus }>`
 
 interface BountyCardProps extends BountyCard {
   onclick: (bountyId: string, status?: BountyCardStatus, ticketGroup?: string) => void;
+  onPayBounty?: (bountyId: string) => void;
 }
+
+const ActionMenu = ({ status, onPay }: { status?: BountyCardStatus; onPay: () => void }) => {
+  const showMenu = ['COMPLETED', 'IN_REVIEW', 'IN_PROGRESS'].includes(status || '');
+
+  if (!showMenu) return null;
+
+  const MenuButton = styled.button`
+    border: none;
+    background: none;
+    padding: 4px;
+    cursor: pointer;
+    color: ${colors.light.text2};
+    &:hover {
+      color: ${colors.light.primaryColor};
+    }
+  `;
+
+  const Dropdown = styled.div`
+    position: absolute;
+    right: 0;
+    top: 100%;
+    background: white;
+    border: 1px solid ${colors.light.grayish.G300};
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    z-index: 1;
+    display: none;
+
+    ${MenuButton}:focus-within & {
+      display: block;
+    }
+  `;
+
+  const MenuItem = styled.button`
+    width: 100%;
+    padding: 8px 16px;
+    border: none;
+    background: none;
+    text-align: left;
+    cursor: pointer;
+    &:hover {
+      background: ${colors.light.grayish.G100};
+    }
+  `;
+
+  return (
+    <MenuButton onClick={(e) => e.stopPropagation()}>
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+        <path d="M6 12a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" fill="currentColor" />
+        <path d="M12 12a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" fill="currentColor" />
+        <path d="M18 12a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" fill="currentColor" />
+      </svg>
+      <Dropdown>
+        <MenuItem onClick={onPay}>Pay Bounty</MenuItem>
+      </Dropdown>
+    </MenuButton>
+  );
+};
 
 const BountyCardComponent: React.FC<BountyCardProps> = ({
   id,
   title,
   features,
   phase,
-  assignee_img,
   workspace,
   status,
   onclick,
   assignee_name,
-  ticket_group
+  ticket_group,
+  onPayBounty
 }: BountyCardProps) => (
   <CardContainer isDraft={status === 'DRAFT'} onClick={() => onclick(id, status, ticket_group)}>
     <CardHeader>
@@ -146,11 +189,9 @@ const BountyCardComponent: React.FC<BountyCardProps> = ({
         {title}
         <span style={{ fontSize: '16px', marginTop: '10px' }}>{assignee_name}</span>
       </CardTitle>
-      {assignee_img && (
-        <AssignerPic>
-          <img src={assignee_img} alt="Assigner" />
-        </AssignerPic>
-      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <ActionMenu status={status} onPay={() => onPayBounty?.(id)} />
+      </div>
     </CardHeader>
 
     <RowT>
@@ -180,7 +221,6 @@ BountyCardComponent.propTypes = {
   phase: PropTypes.shape({
     name: PropTypes.string
   }) as PropTypes.Validator<BountyCard['phase']>,
-  assignee_img: PropTypes.string,
   workspace: PropTypes.shape({
     name: PropTypes.string
   }) as PropTypes.Validator<BountyCard['workspace']>,
@@ -192,7 +232,8 @@ BountyCardComponent.propTypes = {
     'COMPLETED',
     'PAID'
   ] as BountyCardStatus[]),
-  onclick: PropTypes.func.isRequired
+  onclick: PropTypes.func.isRequired,
+  onPayBounty: PropTypes.func
 };
 
 export default BountyCardComponent;

--- a/src/people/WorkSpacePlanner/BountyCard/index.tsx
+++ b/src/people/WorkSpacePlanner/BountyCard/index.tsx
@@ -258,7 +258,13 @@ const ActionMenu = ({ status, onPay }: { status?: BountyCardStatus; onPay: () =>
           setIsOpen(!isOpen);
         }}
       >
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          data-testid="action-menu-button"
+        >
           <path d="M6 12a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" fill="currentColor" />
           <path d="M12 12a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" fill="currentColor" />
           <path d="M18 12a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" fill="currentColor" />

--- a/src/store/interface.ts
+++ b/src/store/interface.ts
@@ -547,6 +547,7 @@ export interface BountyCard {
   pow?: number;
   ticket_uuid?: string;
   ticket_group?: string;
+  bounty_price?: number;
 }
 
 export type BountyReviewStatus = 'New' | 'Accepted' | 'Rejected' | 'Change Requested';


### PR DESCRIPTION
## Describe your changes
 ### Changes
- Removed the assigned individual's avatar from the Bounty Card (name remains visible).
-  Added an action menu (three-dot icon) to each Bounty Card.
- Clicking the action menu reveals a dropdown menu.
- Included a "Pay Bounty" option in the action menu.
- Implemented API call to trigger the correct endpoint when "Pay Bounty" is clicked.
- Ensured the action menu is responsive and functional on mobile devices.
- Restricted the "Pay Bounty" option to all bounties except those in "DRAFT" and "TODO" statuses.
-  Verified that the UI aligns with the provided design specifications.

### Testing
- Verified the action menu appears correctly on all Bounty Cards.
- Tested the "Pay Bounty" option to ensure it triggers the correct API endpoint.
- Checked that the menu is responsive and works on mobile devices.
- Confirmed that "Pay Bounty" is not available for "DRAFT" and "TODO" bounties.

### Backend Changes Required
- The Bounty Cards endpoint should also return bounty amout as "bounty_price" so everything syncs correctly with the frontend. `${TribesURL}/gobounties/bounty-cards?${searchParams.toString()}`. Since bounty data is already being processed and passed from the backend it will make lots more sense to pass bounty amount in the response. Rather than fetching the all bounties on the frontend and filtering for the bounty which will eventually slow down the page. Something we are currently working on fixing for other pages

https://www.loom.com/share/ed2d49186a19441ca940f56bcdb981a6?sid=999ac212-659b-4b5c-b744-7f5780e6853e

## Issue ticket number and link
https://community.sphinx.chat/bounty/3837

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested on Chrome and Firefox
- [X] I have tested on a mobile device
- [X] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend