### PR TITLE
Add Option to Blur Workspace Budget Display

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+
+export const useLocalStorage = (key: string, defaultValue: boolean) => {
+  const [value, setValue] = useState(() => {
+    const storedValue = localStorage.getItem(key);
+    return storedValue ? JSON.parse(storedValue) : defaultValue;
+  });
+
+  useEffect(() => {
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === key) {
+        setValue(event.newValue ? JSON.parse(event.newValue) : defaultValue);
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => window.removeEventListener('storage', handleStorageChange);
+  }, [key, defaultValue]);
+
+  const setStoredValue = (newValue: boolean) => {
+    setValue(newValue);
+    localStorage.setItem(key, JSON.stringify(newValue));
+    // Trigger storage event to notify other tabs
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key,
+        newValue: JSON.stringify(newValue)
+      })
+    );
+  };
+
+  return [value, setStoredValue] as const;
+};

--- a/src/people/widgetViews/BudgetWrap.tsx
+++ b/src/people/widgetViews/BudgetWrap.tsx
@@ -50,6 +50,10 @@ export const BudgetWrapComponent = (props: { org: Workspace | undefined; uuid: s
   const [isOpenBudget, setIsOpenBudget] = useState<boolean>(false);
   const [paymentsHistory, setPaymentsHistory] = useState<PaymentHistory[]>([]);
   const [invoiceStatus, setInvoiceStatus] = useState(false);
+  const [showBalances, setShowBalances] = useState(() => {
+    const storedValue = localStorage.getItem('showBalances');
+    return storedValue ? JSON.parse(storedValue) : true;
+  });
 
   const closeHistoryHandler = () => {
     setIsOpenHistory(false);
@@ -173,11 +177,18 @@ export const BudgetWrapComponent = (props: { org: Workspace | undefined; uuid: s
   const openCountText = orgBudget && orgBudget.open_count ? orgBudget.open_count : 0;
   const openBudget = orgBudget && orgBudget.open_budget ? orgBudget.open_budget : 0;
 
+  const toggleBalances = () => {
+    const newValue = !showBalances;
+    setShowBalances(newValue);
+    localStorage.setItem('showBalances', JSON.stringify(newValue));
+  };
+
   return (
     <>
       <ActionWrap>
         <ActionHeader>
-          Balance <BalanceImg src={balanceIcon} />
+          Balance{' '}
+          <BalanceImg src={balanceIcon} onClick={toggleBalances} style={{ cursor: 'pointer' }} />
         </ActionHeader>
         <HeadButtonWrap forSmallScreen={true}>
           <Button
@@ -235,11 +246,12 @@ export const BudgetWrapComponent = (props: { org: Workspace | undefined; uuid: s
                   </BudgetHeaderWrap>
                   <ViewBudgetTextWrap>
                     <Budget data-testid="current-balance-amount">
-                      {orgBudgetText.toLocaleString()} <Grey>SATS</Grey>
+                      {showBalances ? `${orgBudgetText.toLocaleString()}` : '*****'}{' '}
+                      <Grey>SATS</Grey>
                     </Budget>
                     <Budget className="budget-small">
                       <BalanceAmountImg src={balanceVector} />
-                      {satToUsd(orgBudgetText)} <Grey>USD</Grey>
+                      {showBalances ? satToUsd(orgBudgetText) : '*****'} <Grey>USD</Grey>
                     </Budget>
                   </ViewBudgetTextWrap>
                 </BudgetData>
@@ -257,12 +269,12 @@ export const BudgetWrapComponent = (props: { org: Workspace | undefined; uuid: s
                   </BudgetHeaderWrap>
                   <ViewBudgetTextWrap>
                     <Budget>
-                      {completedBudget.toLocaleString()}
-                      <Grey>SATS</Grey>
+                      {showBalances ? `${completedBudget.toLocaleString()}` : '*****'}
+                      <Grey> SATS</Grey>
                     </Budget>
                     <Budget className="budget-small">
                       <BalanceAmountImg src={balanceVector} />
-                      {satToUsd(completedBudget)} <Grey>USD</Grey>
+                      {showBalances ? satToUsd(completedBudget) : '*****'} <Grey>USD</Grey>
                     </Budget>
                   </ViewBudgetTextWrap>
                 </BudgetData>
@@ -280,12 +292,12 @@ export const BudgetWrapComponent = (props: { org: Workspace | undefined; uuid: s
                   </BudgetHeaderWrap>
                   <ViewBudgetTextWrap>
                     <Budget>
-                      {assignedBudget.toLocaleString()}
-                      <Grey>SATS</Grey>
+                      {showBalances ? `${assignedBudget.toLocaleString()}` : '*****'}
+                      <Grey> SATS</Grey>
                     </Budget>
                     <Budget className="budget-small">
                       <BalanceAmountImg src={balanceVector} />
-                      {satToUsd(assignedBudget)} <Grey>USD</Grey>
+                      {showBalances ? satToUsd(assignedBudget) : '*****'} <Grey>USD</Grey>
                     </Budget>
                   </ViewBudgetTextWrap>
                 </BudgetData>
@@ -303,12 +315,12 @@ export const BudgetWrapComponent = (props: { org: Workspace | undefined; uuid: s
                   </BudgetHeaderWrap>
                   <ViewBudgetTextWrap>
                     <Budget>
-                      {openBudget.toLocaleString()}
-                      <Grey>SATS</Grey>
+                      {showBalances ? `${openBudget.toLocaleString()}` : '*****'}
+                      <Grey> SATS</Grey>
                     </Budget>
                     <Budget className="budget-small">
                       <BalanceAmountImg src={balanceVector} />
-                      {satToUsd(openBudget)} <Grey>USD</Grey>
+                      {showBalances ? satToUsd(openBudget) : '*****'} <Grey>USD</Grey>
                     </Budget>
                   </ViewBudgetTextWrap>
                 </BudgetData>

--- a/src/people/widgetViews/BudgetWrap.tsx
+++ b/src/people/widgetViews/BudgetWrap.tsx
@@ -12,6 +12,7 @@ import { useStores } from 'store';
 import { EuiFlexGrid, EuiFlexItem, useIsWithinBreakpoints, EuiIcon } from '@elastic/eui';
 import { Link, useRouteMatch } from 'react-router-dom';
 import { Button } from 'components/common';
+import { useLocalStorage } from 'hooks/useLocalStorage';
 import balanceIcon from '../../public/static/toll.svg';
 import balanceVector from '../../public/static/balancevector.svg';
 import {
@@ -50,10 +51,7 @@ export const BudgetWrapComponent = (props: { org: Workspace | undefined; uuid: s
   const [isOpenBudget, setIsOpenBudget] = useState<boolean>(false);
   const [paymentsHistory, setPaymentsHistory] = useState<PaymentHistory[]>([]);
   const [invoiceStatus, setInvoiceStatus] = useState(false);
-  const [showBalances, setShowBalances] = useState(() => {
-    const storedValue = localStorage.getItem('showBalances');
-    return storedValue ? JSON.parse(storedValue) : true;
-  });
+  const [showBalances, setShowBalances] = useLocalStorage('showBalances', true);
 
   const closeHistoryHandler = () => {
     setIsOpenHistory(false);
@@ -178,9 +176,7 @@ export const BudgetWrapComponent = (props: { org: Workspace | undefined; uuid: s
   const openBudget = orgBudget && orgBudget.open_budget ? orgBudget.open_budget : 0;
 
   const toggleBalances = () => {
-    const newValue = !showBalances;
-    setShowBalances(newValue);
-    localStorage.setItem('showBalances', JSON.stringify(newValue));
+    setShowBalances(!showBalances);
   };
 
   return (

--- a/src/people/widgetViews/workspace/WorkspaceBudget.tsx
+++ b/src/people/widgetViews/workspace/WorkspaceBudget.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { DollarConverter, satToUsd, userHasRole } from 'helpers';
 import { useStores } from 'store';
 import styled from 'styled-components';
+import { useLocalStorage } from 'hooks/useLocalStorage';
 
 const WorkspaceTextWrap = styled.div`
   margin-left: 1.5rem;
@@ -76,9 +77,13 @@ const CurrencyUnit = styled.span`
 
 const WorkspaceBudget = (props: { user_pubkey: string; org: any }) => {
   const [userRoles, setUserRoles] = useState<any[]>([]);
-
   const { main, ui } = useStores();
   const { user_pubkey, org } = props;
+  const [showBalances, setShowBalances] = useLocalStorage('showBalances', true);
+
+  const toggleBalances = () => {
+    setShowBalances(!showBalances);
+  };
 
   const isWorkspaceAdmin =
     org?.owner_pubkey &&
@@ -105,12 +110,12 @@ const WorkspaceBudget = (props: { user_pubkey: string; org: any }) => {
         {org.name}
       </WorkspaceText>
       {hasAccess && (
-        <WorkspaceBudgetText href={`/workspace/${org.uuid}/activities`}>
-          {DollarConverter(org.budget ?? 0)}
+        <WorkspaceBudgetText onClick={toggleBalances} style={{ cursor: 'pointer' }}>
+          {showBalances ? DollarConverter(org.budget ?? 0) : '****'}
           <CurrencyUnit>
             {' SAT'}
             <SatsGap>/</SatsGap>
-            {satToUsd(org.budget ?? 0)} USD
+            {showBalances ? satToUsd(org.budget ?? 0) : '****'} USD
           </CurrencyUnit>
         </WorkspaceBudgetText>
       )}

--- a/src/people/widgetViews/workspace/WorkspaceBudget.tsx
+++ b/src/people/widgetViews/workspace/WorkspaceBudget.tsx
@@ -79,11 +79,7 @@ const WorkspaceBudget = (props: { user_pubkey: string; org: any }) => {
   const [userRoles, setUserRoles] = useState<any[]>([]);
   const { main, ui } = useStores();
   const { user_pubkey, org } = props;
-  const [showBalances, setShowBalances] = useLocalStorage('showBalances', true);
-
-  const toggleBalances = () => {
-    setShowBalances(!showBalances);
-  };
+  const [showBalances] = useLocalStorage('showBalances', true);
 
   const isWorkspaceAdmin =
     org?.owner_pubkey &&
@@ -110,7 +106,7 @@ const WorkspaceBudget = (props: { user_pubkey: string; org: any }) => {
         {org.name}
       </WorkspaceText>
       {hasAccess && (
-        <WorkspaceBudgetText onClick={toggleBalances} style={{ cursor: 'pointer' }}>
+        <WorkspaceBudgetText href={`/workspace/${org.uuid}/activities`}>
           {showBalances ? DollarConverter(org.budget ?? 0) : '****'}
           <CurrencyUnit>
             {' SAT'}


### PR DESCRIPTION
## Closes: #1151 

## Describe your changes

This PR introduces a new feature that allows users to blur their workspace budget for improved privacy. Users can now toggle the blurring of the workspace budget, which replaces the displayed budget with (*). The actual budget value remains accessible when the setting is disabled.

### Budget Display Logic: 
Updated the workspace budget display logic to show (*) when the blurring feature is enabled.

### Persistent Storage: 
Implemented persistent storage for the user's blur preference using local storage or a backend solution.

## Issue ticket number and link
https://www.loom.com/share/050340517cce4e0eadc4ae75cff880c2?sid=c407e45d-58d9-49f1-9ac4-414d819a6a07

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested on Chrome and Firefox
- [X] I have tested on a mobile device
- [X] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend