### PR TITLE
Add Thinking vs Speed Toggle to Ticket Editor

### DIFF
--- a/src/components/common/TicketEditor/TicketEditor.tsx
+++ b/src/components/common/TicketEditor/TicketEditor.tsx
@@ -654,7 +654,20 @@ const TicketEditor = observer(
         if (!isEnabled) return;
 
         if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-          setIsThinking((prev) => (prev === 'speed' ? 'thinking' : 'speed'));
+          setIsThinking((prev) => {
+            const newMode = prev === 'speed' ? 'thinking' : 'speed';
+
+            setTimeout(() => {
+              const buttonToFocus = document.querySelector(
+                `[role="radio"][aria-checked="true"]`
+              ) as HTMLElement;
+              if (buttonToFocus) {
+                buttonToFocus.focus();
+              }
+            }, 0);
+
+            return newMode;
+          });
         }
 
         if (e.key === 'Enter' || e.key === ' ') {

--- a/src/components/common/TicketEditor/TicketEditor.tsx
+++ b/src/components/common/TicketEditor/TicketEditor.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/typedef */
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useStores } from 'store';
 import { EuiGlobalToastList, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiIcon } from '@elastic/eui';
@@ -33,6 +33,7 @@ import { Toast } from '../../../people/widgetViews/workspace/interface';
 import { uiStore } from '../../../store/ui';
 import { Select, Option } from '../../../people/widgetViews/workspace/style.ts';
 import { useDeleteConfirmationModal } from '../DeleteConfirmationModal';
+import { useFeatureFlag } from '../../../hooks/useFeatureFlag.ts';
 import { TicketTextAreaComp } from './TicketTextArea.tsx';
 
 interface LogEntry {
@@ -72,12 +73,46 @@ const SwitcherContainer = styled.div`
   width: fit-content;
 `;
 
+const ToggleContainer = styled.div`
+  margin-top: 20px;
+  display: flex;
+  background-color: white;
+  border-radius: 6px;
+  padding: 4px;
+  width: fit-content;
+`;
+
 const SwitcherButton = styled.button<{ isActive: boolean }>`
   padding: 8px 16px;
   border: none;
   border-radius: 16px;
   cursor: pointer;
   font-size: 14px;
+  font-weight: 500;
+  transition: all 0.3s ease;
+
+  ${({ isActive }) =>
+    isActive
+      ? `
+    background-color: #007bff;
+    color: white;
+    box-shadow: 0 2px 4px rgba(0, 123, 255, 0.2);
+  `
+      : `
+    background-color: transparent;
+    color: #333;
+    &:hover {
+      background-color: rgba(0, 123, 255, 0.1);
+    }
+  `}
+`;
+
+const ToggleButton = styled.button<{ isActive: boolean }>`
+  padding: 8px 16px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 16px;
   font-weight: 500;
   transition: all 0.3s ease;
 
@@ -253,6 +288,7 @@ const TicketEditor = observer(
     );
     const [isCopying, setIsCopying] = useState(false);
     const [activeMode, setActiveMode] = useState<'preview' | 'edit'>('edit');
+    const [isThinking, setIsThinking] = useState<'speed' | 'thinking'>('thinking');
     const [isButtonDisabled, setIsButtonDisabled] = useState(true);
     const { main } = useStores();
     const [isCreatingBounty, setIsCreatingBounty] = useState(false);
@@ -260,6 +296,7 @@ const TicketEditor = observer(
     const [lastLogLine, setLastLogLine] = useState('');
     const ui = uiStore;
     const { openDeleteConfirmation } = useDeleteConfirmationModal();
+    const { isEnabled } = useFeatureFlag('thinking');
 
     const groupTickets = useMemo(
       () => phaseTicketStore.getTicketsByGroup(ticketData.ticket_group as string),
@@ -612,6 +649,22 @@ const TicketEditor = observer(
       });
     };
 
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (!isEnabled) return;
+
+        if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+          setIsThinking((prev) => (prev === 'speed' ? 'thinking' : 'speed'));
+        }
+
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          setIsThinking((prev) => (prev === 'speed' ? 'thinking' : 'speed'));
+        }
+      },
+      [isEnabled, setIsThinking]
+    );
+
     return (
       <TicketContainer>
         <EuiFlexGroup alignItems="center" gutterSize="s">
@@ -761,6 +814,33 @@ const TicketEditor = observer(
               )}
             </EditorWrapper>
             <TicketButtonGroup>
+              {isEnabled && (
+                <ToggleContainer
+                  tabIndex={0}
+                  onKeyDown={handleKeyDown}
+                  role="radiogroup"
+                  aria-label="Toggle Thinking Mode"
+                >
+                  <ToggleButton
+                    isActive={isThinking === 'speed'}
+                    onClick={() => setIsThinking('speed')}
+                    tabIndex={0}
+                    role="radio"
+                    aria-checked={isThinking === 'speed'}
+                  >
+                    Speed
+                  </ToggleButton>
+                  <ToggleButton
+                    isActive={isThinking === 'thinking'}
+                    onClick={() => setIsThinking('thinking')}
+                    tabIndex={0}
+                    role="radio"
+                    aria-checked={isThinking === 'thinking'}
+                  >
+                    Thinking
+                  </ToggleButton>
+                </ToggleContainer>
+              )}
               {showSWWFLink && swwfLink && (
                 <ChainOfThought>
                   <h6>Hive - Chain of Thought</h6>

--- a/src/components/common/TicketEditor/__tests__/TicketEditor.spec.tsx
+++ b/src/components/common/TicketEditor/__tests__/TicketEditor.spec.tsx
@@ -1,0 +1,282 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TicketEditor from '../TicketEditor';
+import { useFeatureFlag } from '../../../../hooks/useFeatureFlag';
+import { TicketStatus, Author } from '../../../../store/interface';
+
+jest.mock('../../../../hooks/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn()
+}));
+
+jest.mock('store', () => ({
+  useStores: () => ({
+    main: {
+      createUpdateTicket: jest.fn().mockResolvedValue(200),
+      sendTicketForReview: jest.fn().mockResolvedValue(true),
+      deleteTicket: jest.fn().mockResolvedValue(true),
+      getTicketsByGroup: jest.fn().mockResolvedValue([])
+    }
+  })
+}));
+
+jest.mock('store/snippetStore.ts', () => ({
+  snippetStore: {
+    loadSnippets: jest.fn(),
+    getAllSnippets: jest.fn().mockReturnValue([])
+  }
+}));
+
+jest.mock('store/workspace-ticket.ts', () => ({
+  workspaceTicketStore: {
+    getTicketsByGroup: jest.fn().mockReturnValue([]),
+    getLatestVersionFromGroup: jest.fn().mockReturnValue({ version: 1 }),
+    addTicket: jest.fn(),
+    clearTickets: jest.fn()
+  }
+}));
+
+jest.mock('../../../../store/phase', () => ({
+  phaseTicketStore: {
+    getLatestVersionFromGroup: jest.fn().mockReturnValue({ version: 1 }),
+    getTicketsByGroup: jest.fn().mockReturnValue([]),
+    getTicketByVersion: jest
+      .fn()
+      .mockReturnValue({ name: 'Test Ticket', description: 'Test Description' }),
+    addTicket: jest.fn(),
+    clearPhaseTickets: jest.fn()
+  }
+}));
+
+jest.mock('../../../../store/ui', () => ({
+  uiStore: {
+    meInfo: { pubkey: '123', owner_alias: 'Test User' }
+  }
+}));
+
+jest.mock('../../DeleteConfirmationModal', () => ({
+  useDeleteConfirmationModal: () => ({
+    openDeleteConfirmation: jest.fn()
+  })
+}));
+
+jest.mock('../TicketTextArea.tsx', () => ({
+  TicketTextAreaComp: () => <div data-testid="ticket-textarea">Mocked Text Area</div>
+}));
+
+jest.mock('people/utils/RenderMarkdown.tsx', () => ({
+  renderMarkdown: (text: string) => <div data-testid="markdown-preview">{text}</div>
+}));
+
+describe('TicketEditor Thinking/Speed Toggle', () => {
+  const mockTicketData = {
+    uuid: 'test-uuid',
+    name: 'Test Ticket',
+    sequence: 1,
+    dependency: [],
+    description: 'Test Description',
+    status: 'DRAFT' as TicketStatus,
+    version: 1,
+    feature_uuid: 'feature-uuid',
+    phase_uuid: 'phase-uuid',
+    category: 'Web development',
+    amount: 0,
+    ticket_group: 'group-uuid',
+    author: 'HUMAN' as Author,
+    author_id: '123'
+  };
+
+  const defaultProps = {
+    ticketData: mockTicketData,
+    logs: [],
+    websocketSessionId: 'session-id',
+    draggableId: 'draggable-id',
+    hasInteractiveChildren: false,
+    getPhaseTickets: jest.fn().mockResolvedValue([]),
+    workspaceUUID: 'workspace-uuid'
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    document.querySelector = jest.fn().mockReturnValue({
+      focus: jest.fn()
+    });
+  });
+
+  test('should not render toggle when feature flag is disabled', () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue({ isEnabled: false });
+
+    waitFor(() => {
+      render(<TicketEditor {...defaultProps} />);
+
+      expect(
+        screen.queryByRole('radiogroup', { name: /toggle thinking mode/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('should render toggle when feature flag is enabled', () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue({ isEnabled: true });
+
+    waitFor(() => {
+      render(<TicketEditor {...defaultProps} />);
+
+      expect(screen.getByRole('radiogroup', { name: /toggle thinking mode/i })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /speed/i })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /thinking/i })).toBeInTheDocument();
+    });
+  });
+
+  test('should default to thinking mode', () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue({ isEnabled: true });
+
+    waitFor(() => {
+      render(<TicketEditor {...defaultProps} />);
+
+      const thinkingButton = screen.getByRole('radio', { name: /thinking/i });
+      const speedButton = screen.getByRole('radio', { name: /speed/i });
+
+      expect(thinkingButton).toHaveAttribute('aria-checked', 'true');
+      expect(speedButton).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  test('should toggle mode when clicking buttons', () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue({ isEnabled: true });
+
+    waitFor(() => {
+      render(<TicketEditor {...defaultProps} />);
+
+      const thinkingButton = screen.getByRole('radio', { name: /thinking/i });
+      const speedButton = screen.getByRole('radio', { name: /speed/i });
+
+      expect(thinkingButton).toHaveAttribute('aria-checked', 'true');
+      expect(speedButton).toHaveAttribute('aria-checked', 'false');
+
+      fireEvent.click(speedButton);
+
+      expect(thinkingButton).toHaveAttribute('aria-checked', 'false');
+      expect(speedButton).toHaveAttribute('aria-checked', 'true');
+
+      fireEvent.click(thinkingButton);
+
+      expect(thinkingButton).toHaveAttribute('aria-checked', 'true');
+      expect(speedButton).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  test('should toggle mode with keyboard arrow keys', async () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue({ isEnabled: true });
+
+    waitFor(() => {
+      render(<TicketEditor {...defaultProps} />);
+
+      const toggleContainer = screen.getByRole('radiogroup', { name: /toggle thinking mode/i });
+      const thinkingButton = screen.getByRole('radio', { name: /thinking/i });
+      const speedButton = screen.getByRole('radio', { name: /speed/i });
+
+      expect(thinkingButton).toHaveAttribute('aria-checked', 'true');
+      expect(speedButton).toHaveAttribute('aria-checked', 'false');
+
+      fireEvent.keyDown(toggleContainer, { key: 'ArrowRight' });
+
+      expect(thinkingButton).toHaveAttribute('aria-checked', 'false');
+      expect(speedButton).toHaveAttribute('aria-checked', 'true');
+      expect(document.querySelector).toHaveBeenCalledWith('[role="radio"][aria-checked="true"]');
+
+      fireEvent.keyDown(toggleContainer, { key: 'ArrowLeft' });
+
+      expect(thinkingButton).toHaveAttribute('aria-checked', 'true');
+      expect(speedButton).toHaveAttribute('aria-checked', 'false');
+      expect(document.querySelector).toHaveBeenCalledWith('[role="radio"][aria-checked="true"]');
+    });
+  });
+
+  test('should toggle mode with Enter key', () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue({ isEnabled: true });
+
+    waitFor(() => {
+      render(<TicketEditor {...defaultProps} />);
+
+      const toggleContainer = screen.getByRole('radiogroup', { name: /toggle thinking mode/i });
+      const thinkingButton = screen.getByRole('radio', { name: /thinking/i });
+      const speedButton = screen.getByRole('radio', { name: /speed/i });
+
+      expect(thinkingButton).toHaveAttribute('aria-checked', 'true');
+      expect(speedButton).toHaveAttribute('aria-checked', 'false');
+
+      fireEvent.keyDown(toggleContainer, { key: 'Enter' });
+
+      expect(thinkingButton).toHaveAttribute('aria-checked', 'false');
+      expect(speedButton).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+
+  test('should toggle mode with Space key', () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue({ isEnabled: true });
+
+    waitFor(() => {
+      render(<TicketEditor {...defaultProps} />);
+
+      const toggleContainer = screen.getByRole('radiogroup', { name: /toggle thinking mode/i });
+      const thinkingButton = screen.getByRole('radio', { name: /thinking/i });
+      const speedButton = screen.getByRole('radio', { name: /speed/i });
+
+      expect(thinkingButton).toHaveAttribute('aria-checked', 'true');
+      expect(speedButton).toHaveAttribute('aria-checked', 'false');
+
+      fireEvent.keyDown(toggleContainer, { key: ' ' });
+
+      expect(thinkingButton).toHaveAttribute('aria-checked', 'false');
+      expect(speedButton).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+
+  test('should prevent default on Enter and Space keys', () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue({ isEnabled: true });
+
+    waitFor(() => {
+      render(<TicketEditor {...defaultProps} />);
+
+      const toggleContainer = screen.getByRole('radiogroup', { name: /toggle thinking mode/i });
+
+      const enterEvent = {
+        key: 'Enter',
+        preventDefault: jest.fn()
+      };
+
+      const spaceEvent = {
+        key: ' ',
+        preventDefault: jest.fn()
+      };
+
+      fireEvent.keyDown(toggleContainer, enterEvent);
+      expect(enterEvent.preventDefault).toHaveBeenCalled();
+
+      fireEvent.keyDown(toggleContainer, spaceEvent);
+      expect(spaceEvent.preventDefault).toHaveBeenCalled();
+    });
+  });
+
+  test('should not respond to keyboard events when feature flag is disabled', () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue({ isEnabled: false });
+
+    waitFor(() => {
+      render(<TicketEditor {...defaultProps} />);
+
+      const container = screen.getByTestId('ticket-textarea').parentElement;
+
+      if (container) {
+        const keyEvent = {
+          key: 'ArrowRight',
+          preventDefault: jest.fn()
+        };
+
+        fireEvent.keyDown(container, keyEvent);
+
+        expect(keyEvent.preventDefault).not.toHaveBeenCalled();
+      }
+    });
+  });
+});


### PR DESCRIPTION
### Describe the Changes:
- Added a toggle switch in the Ticket Editor that allows users to switch between "Thinking" and "Speed" modes for AI responses. 

Daily Bounty: https://community.sphinx.chat/bounty/3911

## Issue ticket number and link:
- **Bounty Number:** [ 3911 ]
- **Link:** [ [https://community.sphinx.chat/bounty/3911](url) ]

### Evidence:

#### `Loom:`

https://www.loom.com/share/8f137761b5234b1ab77ed5339a30f0ec

![image](https://github.com/user-attachments/assets/0d0664a0-e1fe-4d78-83c2-0e902fcd8464)

### `Unit Test`:

![image](https://github.com/user-attachments/assets/a2adac58-4f49-4433-ba77-9165a50e400a)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and demo of changes in my PR