### PR TITLE
feat(workspace): Add a Feature Call UI elements in workspace setting with Edit Modal

### DIFF
--- a/cypress/e2e/62_addFeatureCall.cy.ts
+++ b/cypress/e2e/62_addFeatureCall.cy.ts
@@ -1,0 +1,52 @@
+describe('Check for Feature Call Url placeholder', () => {
+  beforeEach(() => {
+    cy.login('carol');
+    cy.wait(1000);
+  });
+
+  it('Renders with initial placeholder and opens button on edit button click', () => {
+    const WorkSpaceName = 'Workspace Feature 17';
+
+    const workspace = {
+      loggedInAs: 'carol',
+      name: WorkSpaceName,
+      description: 'We are testing out our workspace feature',
+      website: 'https://community.sphinx.chat',
+      github: 'https://github.com/stakwork/sphinx-tribes-frontend'
+    };
+
+    cy.create_workspace(workspace);
+    cy.wait(1000);
+
+    cy.contains(workspace.name).get(`[data-work-name="${workspace.name}"]`).click();
+    cy.wait(1000);
+
+    cy.get('[data-testid="mission-link"]')
+      .invoke('show')
+      .then(($link: JQuery<HTMLElement>) => {
+        const modifiedHref = $link.attr('href');
+        cy.wrap($link).invoke('removeAttr', 'target');
+        cy.wrap($link).click();
+        cy.url().should('include', modifiedHref);
+      });
+    cy.wait(1000);
+
+    cy.contains('Not Configured').should('exist', { timeout: 1000 });
+    cy.get('[data-testid="featurecall-option-btn-1"]').click();
+    cy.wait(1000);
+
+    cy.get('[data-testid="featurecall-edit-btn-1"]').click();
+    cy.wait(1000);
+
+    cy.contains('Edit Feature Call URL').should('exist');
+    cy.get('[data-testid="feature-call-url-input"]').should('have.value', '');
+
+    cy.get('[data-testid="feature-call-url-input"]').type('https://testfeature.com');
+    cy.wait(1000);
+
+    cy.get('[data-testid="add-featurecall-btn"]').click();
+    cy.wait(2000);
+
+    cy.contains('https://testfeature.com').should('exist');
+  });
+});

--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -51,6 +51,7 @@ declare namespace Cypress {
     description: string;
     website?: string;
     github?: string;
+    feature_call?: string;
   };
 
   type InvoiceDetail = {

--- a/src/people/widgetViews/workspace/AddFeatureCallModal.tsx
+++ b/src/people/widgetViews/workspace/AddFeatureCallModal.tsx
@@ -1,0 +1,207 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { useStores } from 'store';
+import { EuiGlobalToastList, EuiLoadingSpinner } from '@elastic/eui';
+import { Toast } from './interface';
+import {
+  TextInput,
+  WorkspaceInputContainer,
+  WorkspaceLabel,
+  ActionButton,
+  ButtonWrap
+} from './style';
+
+const AddWorkspaceWrapper = styled.div`
+  min-width: 100%;
+  padding: 3rem 2rem;
+  display: flex;
+  flex-direction: column;
+
+  @media only screen and (max-width: 500px) {
+    padding: 1rem;
+    width: 100%;
+  }
+`;
+
+const AddWorkspaceHeader = styled.h2`
+  color: #3c3f41;
+  font-family: 'Barlow';
+  font-size: 1.875rem;
+  font-style: normal;
+  font-weight: 800;
+  line-height: 1.875rem;
+  margin-bottom: 0;
+  min-width: 100%;
+
+  @media only screen and (max-width: 500px) {
+    text-align: center;
+    font-size: 1.4rem;
+  }
+`;
+
+const WorkspaceDetailsContainer = styled.div`
+  margin-top: 3rem;
+  min-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const FooterContainer = styled.div`
+  display: flex;
+  gap: 2rem;
+  align-items: end;
+  justify-content: space-between;
+  margin-top: 15px;
+`;
+
+const errcolor = '#FF8F80';
+
+interface AddFeatureCallProps {
+  closeHandler: () => void;
+  getFeatureCall: () => void;
+  handleDelete?: () => void;
+  workspace_uuid: string;
+  currentUuid?: string;
+  url?: string;
+}
+
+const AddFeatureCall: React.FC<AddFeatureCallProps> = ({
+  closeHandler,
+  getFeatureCall,
+  workspace_uuid,
+  currentUuid,
+  handleDelete,
+  url
+}: AddFeatureCallProps) => {
+  const [featureCallUrl, setFeatureCallUrl] = useState(url || '');
+  const [featureCallUrlError, setFeatureCallUrlError] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const { main } = useStores();
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  function isValidUrl(url: string) {
+    const pattern = new RegExp(
+      '^([a-zA-Z]+:\\/\\/)?' + // protocol
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
+        '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR IP (v4) address
+        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+        '(\\#[-a-z\\d_]*)?$', // fragment locator
+      'i'
+    );
+    return pattern.test(url);
+  }
+
+  useEffect(() => {
+    if (isValidUrl(featureCallUrl)) {
+      setFeatureCallUrlError(false);
+    } else {
+      setFeatureCallUrlError(true);
+    }
+  }, [featureCallUrl]);
+
+  const handleFeatureCallUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFeatureCallUrl(e.target.value);
+  };
+
+  const addSuccessToast = () => {
+    setToasts([
+      {
+        id: '1',
+        title: 'Feature Call URL',
+        color: 'success',
+        text: 'Feature Call URL added successfully'
+      }
+    ]);
+  };
+
+  const addErrorToast = (text: string) => {
+    setToasts([
+      {
+        id: '2',
+        title: 'Feature Call',
+        color: 'danger',
+        text
+      }
+    ]);
+  };
+
+  const removeToast = () => {
+    setToasts([]);
+  };
+
+  const handleSave = async () => {
+    try {
+      setIsLoading(true);
+      const featureCall = {
+        id: currentUuid || '',
+        workspace_id: workspace_uuid,
+        url: featureCallUrl,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
+      };
+
+      await main.createOrUpdateFeatureCall(featureCall);
+      addSuccessToast();
+      getFeatureCall();
+      closeHandler();
+    } catch (error) {
+      console.error(error);
+      addErrorToast(String(error));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <AddWorkspaceWrapper>
+      <AddWorkspaceHeader>Edit Feature Call URL</AddWorkspaceHeader>
+      <WorkspaceDetailsContainer>
+        <WorkspaceInputContainer
+          feature={true}
+          style={{ color: featureCallUrlError ? errcolor : '' }}
+        >
+          <WorkspaceLabel style={{ color: featureCallUrlError ? errcolor : '' }}>
+            Call url *
+          </WorkspaceLabel>
+          <TextInput
+            placeholder="Feature call url"
+            value={featureCallUrl}
+            feature={true}
+            data-testid="feature-call-url-input"
+            onChange={handleFeatureCallUrlChange}
+            style={{ borderColor: featureCallUrlError ? errcolor : '' }}
+          />
+        </WorkspaceInputContainer>
+      </WorkspaceDetailsContainer>
+      <FooterContainer>
+        <ButtonWrap>
+          <ActionButton data-testid="featurecall-cancel-btn" onClick={closeHandler} color="cancel">
+            Cancel
+          </ActionButton>
+          <ActionButton
+            disabled={featureCallUrlError || !featureCallUrl}
+            data-testid="add-featurecall-btn"
+            color="primary"
+            onClick={handleSave}
+          >
+            {isLoading ? <EuiLoadingSpinner size="m" /> : 'Save'}
+          </ActionButton>
+          {handleDelete && (
+            <ActionButton
+              data-testid="delete-featurecall-btn"
+              color="danger"
+              onClick={handleDelete}
+            >
+              {isLoading ? <EuiLoadingSpinner size="m" /> : 'Delete'}
+            </ActionButton>
+          )}
+        </ButtonWrap>
+      </FooterContainer>
+      <EuiGlobalToastList toasts={toasts} dismissToast={removeToast} toastLifeTimeMs={3000} />
+    </AddWorkspaceWrapper>
+  );
+};
+
+export default AddFeatureCall;

--- a/src/store/interface.ts
+++ b/src/store/interface.ts
@@ -354,6 +354,14 @@ export interface CreateFeatureInput {
   priority?: number;
 }
 
+export interface FeatureCall {
+  id: string;
+  workspace_id: string;
+  url: string;
+  created_at: string;
+  updated_at: string;
+}
+
 // Default data
 export const defaultWorkspaceBudget: WorkspaceBudget = {
   org_uuid: '',

--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -59,7 +59,8 @@ import {
   QuickBountiesResponse,
   QuickTicketsResponse,
   BulkConversionResponse,
-  BulkTicketToBountyRequest
+  BulkTicketToBountyRequest,
+  FeatureCall
 } from './interface';
 
 function makeTorSaveURL(host: string, key: string) {
@@ -4153,6 +4154,82 @@ export class MainStore {
       return response.json();
     } catch (e) {
       console.log('Error deleteCodeGraph', e);
+      return null;
+    }
+  }
+
+  async getWorkspaceFeatureCall(workspace_uuid: string): Promise<FeatureCall | null> {
+    try {
+      if (!uiStore.meInfo) return null;
+      const info = uiStore.meInfo;
+      const response = await fetch(`${TribesURL}/features/call/${workspace_uuid}`, {
+        method: 'GET',
+        mode: 'cors',
+        headers: {
+          'x-jwt': info.tribe_jwt,
+          'Content-Type': 'application/json',
+          'x-session-id': this.getSessionId()
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      return response.json();
+    } catch (e) {
+      console.log('Error getWorkspaceFeatureCall', e);
+      return null;
+    }
+  }
+
+  async createOrUpdateFeatureCall(featureCall: FeatureCall): Promise<any> {
+    try {
+      if (!uiStore.meInfo) return null;
+      const info = uiStore.meInfo;
+      const response = await fetch(`${TribesURL}/features/call`, {
+        method: 'POST',
+        mode: 'cors',
+        headers: {
+          'x-jwt': info.tribe_jwt,
+          'Content-Type': 'application/json',
+          'x-session-id': this.getSessionId()
+        },
+        body: JSON.stringify(featureCall)
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      return response.json();
+    } catch (e) {
+      console.log('Error createOrUpdateFeatureCall', e);
+      return null;
+    }
+  }
+
+  async deleteFeatureCall(workspace_uuid: string): Promise<any> {
+    try {
+      if (!uiStore.meInfo) return null;
+      const info = uiStore.meInfo;
+      const response = await fetch(`${TribesURL}/features/call/${workspace_uuid}`, {
+        method: 'DELETE',
+        mode: 'cors',
+        headers: {
+          'x-jwt': info.tribe_jwt,
+          'Content-Type': 'application/json',
+          'x-session-id': this.getSessionId()
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      return response.json();
+    } catch (e) {
+      console.log('Error deleteFeatureCall', e);
       return null;
     }
   }


### PR DESCRIPTION
This issue adds a way for the workspace admin to add a feature call ui url and edit the url as well. Please check screen recording for full functionality demonstration.

## Describe your changes
<img width="749" alt="Screenshot 2025-03-07 at 12 42 49" src="https://github.com/user-attachments/assets/fa01f5b5-a723-403d-bc16-fa3f879987a2" />

https://github.com/user-attachments/assets/24dbfb53-2acb-48dd-bf51-19f40b0a5ca7





## Issue ticket number and link

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend