### PR TITLE
Update Text Artefact views to ensure we use full window height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ cypress/screenshots
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/people/widgetViews/workspace/VisualScreenViewer.tsx
+++ b/src/people/widgetViews/workspace/VisualScreenViewer.tsx
@@ -35,7 +35,7 @@ const CodeViewer = styled.div`
   border: 1px solid #ddd;
   background-color: #1e1e1e;
   padding: 12px;
-  max-height: 500px;
+  min-height: 65vh;
   z-index: 0;
 `;
 
@@ -44,7 +44,7 @@ const TextViewer = styled.div`
   overflow-y: auto;
   border: 1px solid #ddd;
   padding: 12px;
-  max-height: 500px;
+  min-height: 65vh;
   z-index: 0;
 `;
 
@@ -54,6 +54,11 @@ const PaginationControls = styled.div`
   gap: 4px;
   align-items: center;
   margin-top: 12px;
+  z-index: 100;
+  position: sticky;
+  bottom: 0;
+  background-color: #f9f9f9;
+  padding: 8px 0;
 `;
 
 const Button = styled.button`


### PR DESCRIPTION
## Describe your changes

- [X]  Content area for rendienrg code or markdown extends to the full available window height

- [X]  Paging controls are sticky at the bottom of the page.

- [X]   No regression in view or functionality on the page

![Screenshot from 2025-03-11 07-53-32](https://github.com/user-attachments/assets/c08314ea-dca4-4daa-8309-e9eda87c291f)


## Issue ticket number and link
https://community.sphinx.chat/bounty/3997

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested on Chrome and Firefox
- [X] I have tested on a mobile device
- [X] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend