### PR TITLE
Set Hivechat to Build Mode by Default

### DIFF
--- a/cypress/e2e/19_manageUserRoles.cy.ts
+++ b/cypress/e2e/19_manageUserRoles.cy.ts
@@ -51,8 +51,7 @@ describe('Alice Create an Workspace and then manage user roles', () => {
     cy.contains('bob').get('[data-testid="settings-icon"]').click();
     cy.wait(1000);
 
-    cy.contains('label', 'Withdraw from workspace')
-      .prev('input[type="checkbox"]')
+    cy.contains('label', 'Withdraw from workspace').prev('input[type="checkbox"]');
     cy.wait(1000);
 
     cy.get('body').click(0, 0);

--- a/src/people/hiveChat/index.tsx
+++ b/src/people/hiveChat/index.tsx
@@ -371,7 +371,7 @@ export const HiveChatView: React.FC = observer(() => {
   const [lastLogLine, setLastLogLine] = useState('');
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
-  const [isBuild, setIsBuild] = useState<'Chat' | 'Build'>('Chat');
+  const [isBuild, setIsBuild] = useState<'Chat' | 'Build'>('Build');
   const [actionArtifact, setActionArtifact] = useState<Artifact>();
   const [visualArtifact, setVisualArtifact] = useState<Artifact[]>();
   const [textArtifact, setTextArtifact] = useState<Artifact[]>();


### PR DESCRIPTION
## Describe your changes

When we load the Hive Chat we currently set the default mode to Chat. This change will set the default mode to Build.

![image](https://github.com/user-attachments/assets/c983d576-1f8b-451d-b84a-e6004f928b1d)

## Issue ticket number and link
https://community.sphinx.chat/bounty/4067

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested on Chrome and Firefox
- [X] I have tested on a mobile device
- [X] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend