### PR TITLE
Fix: Add padding to chat bubbles to prevent text overlapping copy icon

### DIFF
--- a/src/people/hiveChat/index.tsx
+++ b/src/people/hiveChat/index.tsx
@@ -173,6 +173,7 @@ const MessageBubble = styled.div<MessageBubbleProps>`
   background-color: ${(props) => (props.isUser ? '#808080' : '#F2F3F5')};
   color: ${(props) => (props.isUser ? 'white' : '#202124')};
   position: relative;
+  padding-right: ${(props) => (!props.isUser ? '30px' : '20px')};
 `;
 
 const InputContainer = styled.div`


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

- https://community.sphinx.chat/p/cs7n8c2tu2rivj8gup0g/bounties/4107/1

## Demo:

https://www.loom.com/share/8c8c44fcd42340f9a7f80c1f9222f10c

