### PR TITLE
Stop Hive artefacts jumping to logs artefact

### DIFF
--- a/src/people/hiveChat/index.tsx
+++ b/src/people/hiveChat/index.tsx
@@ -800,15 +800,6 @@ export const HiveChatView: React.FC = observer(() => {
     processArtifacts();
   }, []);
 
-  useEffect(() => {
-    if (sseArtifact && sseArtifact?.length > 0) {
-      setArtifactTab('logs');
-    }
-    if (!visualArtifact && !codeArtifact) {
-      setArtifactTab('text');
-    }
-  }, [codeArtifact, sseArtifact, visualArtifact]);
-
   const handleUploadComplete = (url: string) => {
     setPdfUrl(url);
     setMessage((prevMessage: string) => {


### PR DESCRIPTION
## Describe your changes

The artifact viewer in Hive Chat was automatically reverting to the "Logs" tab whenever artifacts were updated, regardless of the user's selected tab. This behavior was causing frustration as users would lose their current view.

https://www.loom.com/share/8dfa2309d1fc4eedaec5b8e9cdfa3ad9?sid=41336316-9559-4582-b212-8ac1190feaea


### Changes:
- Removed the useEffect that automatically switched tabs based on artifact availability  

- Artifact tab selection now persists based on user choice  

- Users can manually switch between artifact types (Logs, Code, Screen, Text) without unexpected tab changes

## Issue ticket number and link

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update


## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested on Chrome and Firefox
- [X] I have tested on a mobile device
- [X] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend