### PR TITLE
Retain Phase State on Feature View Across Page Reloads

### DIFF
--- a/src/people/widgetViews/workspace/HiveFeaturesView/HiveFeaturesView.tsx
+++ b/src/people/widgetViews/workspace/HiveFeaturesView/HiveFeaturesView.tsx
@@ -304,7 +304,6 @@ const HiveFeaturesView = observer<HiveFeaturesViewProps>(() => {
   const [phaseNames, setPhaseNames] = useState<{ [key: string]: string }>({});
   const [collapsed, setCollapsed] = useState(false);
   const [data, setData] = useState<QuickBountyTicket[]>([]);
-  const [expandedPhases, setExpandedPhases] = useState<{ [key: string]: boolean }>({});
   const { ui, main } = useStores();
   const [draftTexts, setDraftTexts] = useState<{ [phaseID: string]: string }>({});
   const [toasts, setToasts] = React.useState<any[]>([]);
@@ -452,11 +451,8 @@ const HiveFeaturesView = observer<HiveFeaturesViewProps>(() => {
         for (const phase of phases) {
           names[phase.uuid] = phase.name || 'Untitled Phase';
 
-          if (!(phase.uuid in expandedPhases)) {
-            setExpandedPhases((prev) => ({
-              ...prev,
-              [phase.uuid]: true
-            }));
+          if (!(phase.uuid in quickBountyTicketStore.expandedPhases)) {
+            quickBountyTicketStore.setPhaseExpanded(phase.uuid, true);
           }
         }
         setPhaseNames(names);
@@ -464,17 +460,6 @@ const HiveFeaturesView = observer<HiveFeaturesViewProps>(() => {
     };
     fetchAllPhases();
   }, [featureUuid, main]);
-
-  useEffect(() => {
-    const savedState = localStorage.getItem(`expandedPhases_${featureUuid}`);
-    if (savedState) {
-      setExpandedPhases(JSON.parse(savedState));
-    }
-  }, [featureUuid]);
-
-  useEffect(() => {
-    localStorage.setItem(`expandedPhases_${featureUuid}`, JSON.stringify(expandedPhases));
-  }, [expandedPhases, featureUuid]);
 
   useEffect(() => {
     const socket = createSocketInstance();
@@ -536,10 +521,8 @@ const HiveFeaturesView = observer<HiveFeaturesViewProps>(() => {
   }, [workspaceUuid, main]);
 
   const togglePhase = (phaseID: string) => {
-    setExpandedPhases((prev) => ({
-      ...prev,
-      [phaseID]: !prev[phaseID]
-    }));
+    const currentState = quickBountyTicketStore.expandedPhases[phaseID] !== false;
+    quickBountyTicketStore.setPhaseExpanded(phaseID, !currentState);
   };
 
   const getNavigationURL = (item: QuickBountyTicket) => {
@@ -916,7 +899,7 @@ const HiveFeaturesView = observer<HiveFeaturesViewProps>(() => {
             ) : (
               Object.entries(phaseNames).map(([phaseID, phaseName], index) => {
                 const items = groupedData[phaseID] || [];
-                const isExpanded = expandedPhases[phaseID] !== false;
+                const isExpanded = quickBountyTicketStore.expandedPhases[phaseID] !== false;
                 const draftText = draftTexts[phaseID] || '';
 
                 return (

--- a/src/store/__test__/quickBountyTicketStore.spec.tsx
+++ b/src/store/__test__/quickBountyTicketStore.spec.tsx
@@ -1,0 +1,152 @@
+import { waitFor } from '@testing-library/react';
+import { quickBountyTicketStore } from '../quickBountyTicketStore';
+
+describe('QuickBountyTicketStore', () => {
+  let localStorageMock: { [key: string]: string };
+
+  beforeEach(() => {
+    localStorageMock = {};
+
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: jest.fn((key) => localStorageMock[key]),
+        setItem: jest.fn((key, value) => {
+          localStorageMock[key] = value;
+        }),
+        removeItem: jest.fn((key) => delete localStorageMock[key]),
+        clear: jest.fn(() => {
+          localStorageMock = {};
+        })
+      },
+      writable: true
+    });
+
+    quickBountyTicketStore.quickBountyTickets = [];
+    quickBountyTicketStore.expandedPhases = {};
+  });
+
+  describe('initialization', () => {
+    it('should initialize with empty quickBountyTickets', () => {
+      expect(quickBountyTicketStore.quickBountyTickets).toEqual([]);
+    });
+
+    it('should initialize with empty expandedPhases', () => {
+      expect(quickBountyTicketStore.expandedPhases).toEqual({});
+    });
+
+    it('should load expanded states from localStorage if available', () => {
+      const savedState = { 'phase-1': true, 'phase-2': false };
+      localStorageMock['expandedPhases'] = JSON.stringify(savedState);
+
+      (quickBountyTicketStore as any).loadExpandedStates();
+
+      expect(quickBountyTicketStore.expandedPhases).toEqual(savedState);
+    });
+
+    it('should handle invalid JSON in localStorage', () => {
+      localStorageMock['expandedPhases'] = 'invalid-json';
+
+      (quickBountyTicketStore as any).loadExpandedStates();
+
+      expect(quickBountyTicketStore.expandedPhases).toEqual({});
+    });
+  });
+
+  describe('setPhaseExpanded', () => {
+    it('should update expanded state for a phase', () => {
+      quickBountyTicketStore.setPhaseExpanded('phase-1', true);
+
+      expect(quickBountyTicketStore.expandedPhases['phase-1']).toBe(true);
+    });
+
+    it('should save to localStorage when updating state', () => {
+      quickBountyTicketStore.setPhaseExpanded('phase-1', true);
+
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'expandedPhases',
+        JSON.stringify({ 'phase-1': true })
+      );
+    });
+
+    it('should handle multiple phase states', () => {
+      quickBountyTicketStore.setPhaseExpanded('phase-1', true);
+      quickBountyTicketStore.setPhaseExpanded('phase-2', false);
+
+      expect(quickBountyTicketStore.expandedPhases).toEqual({
+        'phase-1': true,
+        'phase-2': false
+      });
+    });
+  });
+
+  describe('fetchAndSetQuickData', () => {
+    const mockBounties = {
+      featureID: 'feature-1',
+      phases: {
+        'phase-1': [
+          {
+            bountyID: 1,
+            phaseID: 'phase-1',
+            bountyTitle: 'Test Bounty',
+            status: 'TODO',
+            assignedAlias: 'tester'
+          }
+        ]
+      }
+    };
+
+    const mockTickets = {
+      featureID: 'feature-1',
+      phases: {
+        'phase-1': [
+          {
+            ticketUUID: 'ticket-1',
+            phaseID: 'phase-1',
+            ticketTitle: 'Test Ticket',
+            status: 'TODO',
+            assignedAlias: 'tester'
+          }
+        ]
+      }
+    };
+
+    beforeEach(() => {
+      const mainStore = {
+        fetchQuickBounties: jest.fn().mockResolvedValue(mockBounties),
+        fetchQuickTickets: jest.fn().mockResolvedValue(mockTickets)
+      };
+      quickBountyTicketStore['main'] = mainStore;
+    });
+
+    it('should fetch and process bounties and tickets', async () => {
+      const result = await quickBountyTicketStore.fetchAndSetQuickData('feature-1');
+
+      waitFor(() => {
+        expect(result).toHaveLength(2);
+        expect(result?.find((item) => item.bountyTicket === 'bounty')).toBeTruthy();
+        expect(result?.find((item) => item.bountyTicket === 'ticket')).toBeTruthy();
+      });
+    });
+
+    it('should handle empty response', async () => {
+      quickBountyTicketStore['main'].fetchQuickBounties.mockResolvedValue(null);
+      quickBountyTicketStore['main'].fetchQuickTickets.mockResolvedValue(null);
+
+      const result = await quickBountyTicketStore.fetchAndSetQuickData('feature-1');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle fetch errors', async () => {
+      quickBountyTicketStore['main'].fetchQuickBounties.mockRejectedValue(
+        new Error('Fetch failed')
+      );
+
+      const result = await quickBountyTicketStore.fetchAndSetQuickData('feature-1');
+
+      waitFor(() => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/store/quickBountyTicketStore.tsx
+++ b/src/store/quickBountyTicketStore.tsx
@@ -18,9 +18,35 @@ export interface QuickBountyTicket {
 
 class QuickBountyTicketStore {
   quickBountyTickets: QuickBountyTicket[] = [];
+  expandedPhases: { [key: string]: boolean } = {};
 
   constructor() {
     makeAutoObservable(this);
+    this.loadExpandedStates();
+  }
+
+  private loadExpandedStates() {
+    try {
+      const savedState = localStorage.getItem('expandedPhases');
+      if (savedState) {
+        this.expandedPhases = JSON.parse(savedState);
+      }
+    } catch (error) {
+      console.error('Error loading expanded states:', error);
+    }
+  }
+
+  setPhaseExpanded(phaseId: string, expanded: boolean) {
+    this.expandedPhases[phaseId] = expanded;
+    this.saveExpandedStates();
+  }
+
+  private saveExpandedStates() {
+    try {
+      localStorage.setItem('expandedPhases', JSON.stringify(this.expandedPhases));
+    } catch (error) {
+      console.error('Error saving expanded states:', error);
+    }
   }
 
   async fetchAndSetQuickData(featureUUID: string) {


### PR DESCRIPTION
### Describe the Changes:
- Implemented MobX state management to persist the collapsed/expanded state of each phase across page reloads using local storage.

Daily Bounty: https://community.sphinx.chat/bounty/4116

### `Evidence Loom`:

https://www.loom.com/share/7c82d300c45444d39e6aa06ad4f69a45

### `Unit Tests`:

![image](https://github.com/user-attachments/assets/55b1b8bb-c5ec-425b-a5da-1f6cf14fb92f)

![image](https://github.com/user-attachments/assets/ac1db9cf-3425-4a5d-ba9b-3c2f30fb4506)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome
- [x] New feature (non-breaking change which adds functionality)
- [x] I have provided a screenshot and loom of changes in my PR