### PR TITLE
feat: add prettier plugins for rust and golang in hivechat code artificats

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
     "nock": "^13.3.0",
     "posthog-js": "^1.204.0",
     "prettier": "3.0.3",
+    "prettier-plugin-go-template": "^0.0.15",
+    "prettier-plugin-rust": "^0.1.9",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-dropzone": "^14.2.3",
@@ -214,8 +216,6 @@
   },
   "devDependencies": {
     "@types/react-syntax-highlighter": "^15.5.13",
-    "cypress": "^13.6.3",
-    "prettier-plugin-go-template": "^0.0.15",
-    "prettier-plugin-rust": "^0.1.9"
+    "cypress": "^13.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -214,6 +214,8 @@
   },
   "devDependencies": {
     "@types/react-syntax-highlighter": "^15.5.13",
-    "cypress": "^13.6.3"
+    "cypress": "^13.6.3",
+    "prettier-plugin-go-template": "^0.0.15",
+    "prettier-plugin-rust": "^0.1.9"
   }
 }

--- a/src/helpers/codeFormatter.ts
+++ b/src/helpers/codeFormatter.ts
@@ -30,8 +30,7 @@ export const formatCodeWithPrettier = (code: string, language = 'javascript') =>
     const cleanedCode = code.trim();
     if (!cleanedCode) return code;
 
-    const normalizedLang = language.charAt(0).toUpperCase() + language.slice(1).toLowerCase();
-    const config = parserMap[normalizedLang] || parserMap.javaScript;
+    const config = parserMap[language] || parserMap.javaScript;
 
     return prettier.format(cleanedCode, {
       parser: config.parser,

--- a/src/helpers/codeFormatter.ts
+++ b/src/helpers/codeFormatter.ts
@@ -1,28 +1,37 @@
+import { Plugin } from 'prettier';
 import prettier from 'prettier/standalone';
 import parserBabel from 'prettier/parser-babel';
 import parserHtml from 'prettier/parser-html';
 import parserPostcss from 'prettier/parser-postcss';
 import parserMarkdown from 'prettier/parser-markdown';
+import parserRust from 'prettier-plugin-rust';
+import parserGoTemplate from 'prettier-plugin-go-template';
+
+interface ParserConfig {
+  parser: string;
+  plugins: Plugin[] | object[];
+}
+
+const parserMap: Record<string, ParserConfig> = {
+  javaScript: { parser: 'babel', plugins: [parserBabel] },
+  typeScript: { parser: 'babel', plugins: [parserBabel] },
+  react: { parser: 'babel', plugins: [parserBabel] },
+  html: { parser: 'html', plugins: [parserHtml] },
+  css: { parser: 'css', plugins: [parserPostcss] },
+  markdown: { parser: 'markdown', plugins: [parserMarkdown] },
+  json: { parser: 'json', plugins: [parserBabel] },
+  rust: { parser: 'rust', plugins: [parserRust] },
+  go: { parser: 'go', plugins: [parserGoTemplate] },
+  golang: { parser: 'go', plugins: [parserGoTemplate] }
+};
 
 export const formatCodeWithPrettier = (code: string, language = 'javascript') => {
   try {
     const cleanedCode = code.trim();
     if (!cleanedCode) return code;
 
-    const parserMap = {
-      js: { parser: 'babel', plugins: [parserBabel] },
-      ts: { parser: 'babel', plugins: [parserBabel] },
-      jsx: { parser: 'babel', plugins: [parserBabel] },
-      tsx: { parser: 'babel', plugins: [parserBabel] },
-      html: { parser: 'html', plugins: [parserHtml] },
-      css: { parser: 'css', plugins: [parserPostcss] },
-      md: { parser: 'markdown', plugins: [parserMarkdown] },
-      json: { parser: 'json', plugins: [parserBabel] }
-    };
-
-    const normalizedLang = language.toLowerCase().trim();
-
-    const config = parserMap[normalizedLang] || { parser: 'babel', plugins: [parserBabel] };
+    const normalizedLang = language.charAt(0).toUpperCase() + language.slice(1).toLowerCase();
+    const config = parserMap[normalizedLang] || parserMap.javaScript;
 
     return prettier.format(cleanedCode, {
       parser: config.parser,

--- a/src/people/hiveChat/index.tsx
+++ b/src/people/hiveChat/index.tsx
@@ -893,8 +893,7 @@ export const HiveChatView: React.FC = observer(() => {
         codeArtifacts.forEach(async (artifact) => {
           if (isTextContent(artifact.content)) {
             try {
-              const language =
-                (artifact.content as TextContent).code_metadata?.File.split('.').pop() || 'jsx';
+              const language = (artifact.content as TextContent).language || 'javascript';
               artifact.content.content = await formatCodeWithPrettier(
                 artifact.content.content,
                 language

--- a/yarn.lock
+++ b/yarn.lock
@@ -8160,6 +8160,11 @@ jest@^27.4.3:
     import-local "^3.0.2"
     jest-cli "^27.5.1"
 
+jinx-rust@0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/jinx-rust/-/jinx-rust-0.1.6.tgz#c7bce55d97bfbad76a9b930c01fe6a8629a170d7"
+  integrity sha512-qP+wtQL1PrDDFwtPKhNGtjWOmijCrKdfUHWTV2G/ikxfjrh+cjdvkQTmny9RAsVF0jiui9m+F0INWu4cuRcZeQ==
+
 jiti@^1.19.1:
   version "1.21.0"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.0.tgz#7c97f8fe045724e136a397f7340475244156105d"
@@ -10377,10 +10382,30 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
+prettier-plugin-go-template@^0.0.15:
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-go-template/-/prettier-plugin-go-template-0.0.15.tgz#474952ed72405e528f70bf9cf3f50938c97d8f86"
+  integrity sha512-WqU92E1NokWYNZ9mLE6ijoRg6LtIGdLMePt2C7UBDjXeDH9okcRI3zRqtnWR4s5AloiqyvZ66jNBAa9tmRY5EQ==
+  dependencies:
+    ulid "^2.3.0"
+
+prettier-plugin-rust@^0.1.9:
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-rust/-/prettier-plugin-rust-0.1.9.tgz#1a93b035743fa02a006b4980a1035a260ea9e501"
+  integrity sha512-n1DTTJQaHMdnoG/+nKUvBm3EKsMVWsYES2UPCiOPiZdBrmuAO/pX++m7L3+Hz3uuhtddpH0HRKHB2F3jbtJBOQ==
+  dependencies:
+    jinx-rust "0.1.6"
+    prettier "^2.7.1"
+
 prettier@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
   integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
+
+prettier@^2.7.1:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1, pretty-bytes@^5.6.0:
   version "5.6.0"
@@ -12684,6 +12709,11 @@ typescript@^5.3.2:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
+
+ulid@^2.3.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/ulid/-/ulid-2.4.0.tgz#9d9ee22e63f4390ee1bcd9ad09fca39d8ae0afed"
+  integrity sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Describe your changes

This PR adds Rust and Golang [prettier plugins](https://prettier.io/docs/plugins/#community-plugins) for hivechat code artifacts

### Demo

Tested with Sample Golang and Rust code strings

https://www.loom.com/share/6349a019557f43c08a8b8e2e8604437d?sid=c07032fc-80a5-4aea-b9e6-e56bfe3070df

