### PR TITLE
Add color contrast and keyboard interactions for more accessible search functionality

### DIFF
--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -147,7 +147,11 @@ function SearchBar({
       height={height}
       marginLeft={marginLeft}
     >
+      <label htmlFor="search" hidden>
+        Search
+      </label>
       <input
+        id="search"
         className="SearchText"
         {...props}
         onFocus={() => setExpand(true)}
@@ -162,11 +166,21 @@ function SearchBar({
         }}
         placeholder={props.placeholder}
         style={{ ...props.style }}
+        aria-autocomplete="list"
+        aria-expanded={searchValue.length > 0}
       />
       {searchValue ? (
         <MaterialIcon
           icon="close"
+          role="button"
+          aria-label="Clear search"
+          tabIndex={0}
           onClick={() => erase()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              erase();
+            }
+          }}
           style={{
             position: 'absolute',
             color: color.grayish.G300,

--- a/src/people/widgetViews/BountyHeader.tsx
+++ b/src/people/widgetViews/BountyHeader.tsx
@@ -127,19 +127,19 @@ const FilterContainer = styled.div<styledProps>`
     line-height: 19px;
     display: flex;
     align-items: center;
-    color: ${(p: any) => p.color && p.color.grayish.G200};
+    color: ${(p: any) => p.color && p.color.grayish.G50};
   }
   &:hover {
     .filterImageContainer {
       .materialIconImage {
-        color: ${(p: any) => p.color && p.color.grayish.G50} !important;
+        color: ${(p: any) => p.color && p.color.grayish.G10} !important;
         cursor: pointer;
         font-size: 18px;
         margin-top: 4px;
       }
     }
     .filterText {
-      color: ${(p: any) => p.color && p.color.grayish.G50};
+      color: ${(p: any) => p.color && p.color.grayish.G10};
     }
   }
   &:active {
@@ -490,18 +490,31 @@ const BountyHeader = ({
                 iconStyle={{
                   top: '13px'
                 }}
-                TextColor={color.grayish.G100}
-                TextColorHover={color.grayish.G50}
+                TextColor={color.grayish.G50}
+                TextColorHover={color.grayish.G10}
                 border={`1px solid ${color.grayish.G600}`}
                 borderHover={`1px solid ${color.grayish.G400}`}
                 borderActive={`1px solid ${color.light_blue100}`}
-                iconColor={color.grayish.G300}
-                iconColorHover={color.grayish.G50}
+                iconColor={color.grayish.G50}
+                iconColorHover={color.grayish.G10}
               />
 
               <EuiPopover
                 button={
-                  <FilterContainer onClick={onButtonClick} color={color}>
+                  <FilterContainer
+                    onClick={onButtonClick}
+                    color={color}
+                    role="button"
+                    aria-label={`Filter search, ${filterCountNumber} filter${
+                      filterCountNumber === 1 ? '' : 's'
+                    } applied`}
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        onButtonClick();
+                      }
+                    }}
+                  >
                     <div className="filterImageContainer">
                       <MaterialIcon
                         className="materialIconImage"
@@ -576,9 +589,21 @@ const BountyHeader = ({
                 </FilterCount>
               )}
             </B>
-            <div onClick={() => history.replace('/p')}>
+            <div
+              onClick={() => history.replace('/p')}
+              role="button"
+              aria-label={`Developers, ${developerCount} developers${
+                developerCount === 1 ? '' : 's'
+              } found`}
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  history.replace('/p');
+                }
+              }}
+            >
               <D color={color}>
-                <EuiText className="DText" color={color.grayish.G200}>
+                <EuiText className="DText" color={color.grayish.G50}>
                   Developers
                 </EuiText>
                 <div className="ImageOuterContainer">
@@ -639,18 +664,26 @@ const BountyHeader = ({
               iconStyle={{
                 top: '4px'
               }}
-              TextColor={color.grayish.G400}
-              TextColorHover={color.grayish.G100}
+              TextColor={color.grayish.G50}
+              TextColorHover={color.grayish.G10}
               border={`1px solid ${color.grayish.G500}`}
               borderHover={`1px solid ${color.grayish.G400}`}
               borderActive={`1px solid ${color.light_blue100}`}
-              iconColor={color.grayish.G300}
-              iconColorHover={color.grayish.G100}
+              iconColor={color.grayish.G50}
+              iconColorHover={color.grayish.G10}
             />
 
             <EuiPopover
               button={
-                <FilterContainer onClick={onButtonClick} color={color}>
+                <FilterContainer
+                  onClick={onButtonClick}
+                  color={color}
+                  role="button"
+                  aria-label={`Filter search, ${filterCountNumber} filter${
+                    filterCountNumber === 1 ? '' : 's'
+                  } applied`}
+                  tabIndex={0}
+                >
                   <div className="filterImageContainer">
                     <MaterialIcon
                       className="materialIconImage"


### PR DESCRIPTION
## Describe your changes
Add color contrast and keyboard interactions for more accessible search functionality, based on guidance provided on issue #1237. Keyboard interactions based on recommendations made [here](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#keyboardinteraction)

**Color contrast changes:** 
- Grays used for the text in this section to G50 color code `#5F6368` that passed the color contrast test (AA - used chrome's tool) and G10 `#3C3F41` for the hover state.
  <img width="279" alt="Screenshot 2025-03-26 at 14 24 55" src="https://github.com/user-attachments/assets/4f2adf84-ef5c-4c22-b644-10ecc5c825b0" />

**Screen Reader changes:**
- Label with "Search" is associated with the input search field
- Aria-label used for the buttons for "Clear search", "Filter Search" & "Developers found"

**Keyboard interaction changes:**
- When the focus enters the search field dialog opens if there are auto-complete suggestions, Shift + Tab moves to the previous tabbable button (Leaderboard), escape closes the search, tabbing moves to the "Clear search" icon button then moves focus to the next tabbable elements (Filter Search & Developers). Based on the recommended [keyboard interactions](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#keyboardinteraction) and makes logical search navigation to me

- If enter or space is pressed on the clear search button, text is cleared and search is closed.



https://github.com/user-attachments/assets/e2aae852-782f-4318-85d1-6f99c6e94a9a



## Issue ticket number and link

Bounty: https://community.sphinx.chat/bounty/3990?unlock=683073
Issue: https://github.com/stakwork/sphinx-tribes-frontend/issues/1237

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested on Chrome and Firefox
- [x] I have tested on a mobile device
- [x] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend