### PR TITLE
Update default statistics time frame to last 30 days

### DIFF
--- a/src/pages/superadmin/index.tsx
+++ b/src/pages/superadmin/index.tsx
@@ -60,7 +60,7 @@ export const SuperAdmin = () => {
    * and status for all child components
    * */
   const [endDate, setEndDate] = useState(moment().unix());
-  const [startDate, setStartDate] = useState(moment().subtract(7, 'days').unix());
+  const [startDate, setStartDate] = useState(moment().subtract(30, 'days').unix());
   const [inView, ref] = useInViewPort({
     rootMargin: '0px',
     threshold: 0.25


### PR DESCRIPTION
replaces the now -7 days with now -30 days in the calculation of the statistics on the super admin page.
Open issue: change the default selection on the pulldown menu on the upper right from 7 to 30 as well to match