### PR TITLE
Status UI component moved between Chat History and Chat Box for clear separation

### DIFF
--- a/src/people/hiveChat/ChatStatusDisplay.tsx
+++ b/src/people/hiveChat/ChatStatusDisplay.tsx
@@ -12,7 +12,6 @@ const StatusContainer = styled.div<{ isError: boolean }>`
   align-items: center;
   border-radius: 8px;
   margin-top: auto;
-  margin-bottom: 10px;
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
 `;
 

--- a/src/people/hiveChat/index.tsx
+++ b/src/people/hiveChat/index.tsx
@@ -182,6 +182,10 @@ const ChatHistory = styled.div`
   position: relative;
 `;
 
+const StatusWrapper = styled.div`
+  margin-top: 20px;
+`;
+
 const SplashContainer = styled.div`
   position: absolute;
   top: 50%;
@@ -1633,9 +1637,14 @@ export const HiveChatView: React.FC = observer(() => {
                     </p>
                   </MessageBubble>
                 )}
-
-                {chatStatus && <ChatStatusDisplay chatStatus={chatStatus} />}
               </ChatHistory>
+
+              {chatStatus && (
+                <StatusWrapper>
+                  <ChatStatusDisplay chatStatus={chatStatus} />
+                </StatusWrapper>
+              )}
+
               <InputContainer>
                 <TextArea
                   value={message}


### PR DESCRIPTION
## Describe your changes

- Repositioned ChatStatusDisplay component from inside ChatHistory to between ChatHistory and InputContainer for clearer visual separation of system status messages.

## Bounty Link:

- https://community.sphinx.chat/p/cs7n8c2tu2rivj8gup0g/bounties/4186/1

## Evidence:

https://github.com/user-attachments/assets/b5d08de0-b170-4352-8ff2-02b446e7fef5

![image](https://github.com/user-attachments/assets/c3256304-515e-46ac-8f3f-109df73d2362)

![image](https://github.com/user-attachments/assets/b62327f3-a725-4dad-b07e-163552dccae9)
