### PR TITLE
Add Self Assignment Component to Bounty Modal

### DIFF
--- a/src/people/interfaces.ts
+++ b/src/people/interfaces.ts
@@ -265,6 +265,7 @@ export interface WantedSummaryProps {
   owner_id?: string;
   markPaidOrUnpaid?: ReactNode;
   isEditButtonDisable?: boolean;
+  stakeMin?: number;
 }
 
 export type LocalPaymeentState = 'UNKNOWN' | 'PAID' | 'UNPAID';
@@ -342,6 +343,8 @@ export interface CodingBountiesProps extends WantedSummaryProps {
   assigneeLabel?: { [key: string]: any };
   actionButtons?: boolean | JSX.Element;
   unlock_code?: string;
+  stakeMin?: number;
+  isStakable?: boolean;
 }
 
 export interface CodingViewProps extends WantedSummaryProps {

--- a/src/people/interfaces.ts
+++ b/src/people/interfaces.ts
@@ -343,8 +343,8 @@ export interface CodingBountiesProps extends WantedSummaryProps {
   assigneeLabel?: { [key: string]: any };
   actionButtons?: boolean | JSX.Element;
   unlock_code?: string;
-  stakeMin?: number;
-  isStakable?: boolean;
+  stake_min?: number;
+  is_stakable?: boolean;
 }
 
 export interface CodingViewProps extends WantedSummaryProps {
@@ -446,6 +446,8 @@ export interface WantedViews2Props extends WantedViewsProps {
   fromBountyPage?: boolean;
   activeWorkspace?: string;
   isBountyLandingPage?: boolean;
+  is_stakable?: boolean;
+  stake_min?: number;
 }
 
 export interface AboutViewProps {

--- a/src/people/widgetViews/WantedView.tsx
+++ b/src/people/widgetViews/WantedView.tsx
@@ -125,6 +125,8 @@ function WantedView(props: WantedViews2Props) {
       return (
         <MobileView
           {...props}
+          is_stakable={props.is_stakable}
+          stake_min={props.stake_min}
           labels={labels}
           key={ticketUrl}
           saving={saving ?? false}

--- a/src/people/widgetViews/summaries/WantedSummary.tsx
+++ b/src/people/widgetViews/summaries/WantedSummary.tsx
@@ -60,7 +60,8 @@ function WantedSummary(props: WantedSummaryProps) {
     feature_uuid,
     phase_uuid,
     id,
-    isEditButtonDisable
+    isEditButtonDisable,
+    stakeMin
   } = props;
   const titleString = one_sentence_summary || title || '';
   const bountyPath = `/bounty/${id}`;
@@ -621,6 +622,7 @@ function WantedSummary(props: WantedSummaryProps) {
           isEditButtonDisable={isEditButtonDisable}
           phase_uuid={phase_uuid}
           feature_uuid={feature_uuid}
+          stakeMin={stakeMin}
         />
       );
     }

--- a/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
@@ -61,7 +61,7 @@ import {
 } from './style';
 import { getTwitterLink } from './lib';
 import CodingMobile from './CodingMobile';
-import { BountyEstimates } from './Components';
+import { BountyEstimates, SelfAssignButton } from './Components';
 import CodingBountyProofModal from './CodingBountyProofModal';
 let interval;
 
@@ -123,7 +123,9 @@ function MobileView(props: CodingBountiesProps) {
     isEditButtonDisable,
     completed,
     payment_failed,
-    payment_pending
+    payment_pending,
+    stakeMin,
+    isStakable
   } = props;
   const color = colors['light'];
 
@@ -147,6 +149,8 @@ function MobileView(props: CodingBountiesProps) {
   const [menuOpen, setMenuOpen] = useState<number | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const bountyID = id?.toString() || '';
+  const [showComingSoonModal, setShowComingSoonModal] = useState(false);
+  const [featureFlags, setFeatureFlags] = useState<any>({});
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -717,6 +721,27 @@ function MobileView(props: CodingBountiesProps) {
   let pillColor = color.statusAssigned;
   let pillText = 'assigned';
 
+  useEffect(() => {
+    const fetchFeatureFlags = async () => {
+      try {
+        const response = await main.getFeatureFlags();
+        if (response?.success) {
+          setFeatureFlags(
+            response.data.reduce((acc: any, flag: any) => {
+              acc[flag.name] = flag.enabled;
+              return acc;
+            }, {})
+          );
+        }
+      } catch (error) {
+        console.error('Error fetching feature flags:', error);
+      }
+    };
+    fetchFeatureFlags();
+  }, [main]);
+
+  console.log(featureFlags);
+
   if (isMobile) {
     return (
       <CodingMobile
@@ -844,6 +869,14 @@ function MobileView(props: CodingBountiesProps) {
                   hovercolor={color.button_secondary.hover}
                   shadowcolor={color.button_secondary.shadow}
                   onClick={confirmPaymentHandler}
+                />
+              )}
+
+              {featureFlags.staking && isStakable && (
+                <SelfAssignButton
+                  onClick={() => setShowComingSoonModal(true)}
+                  stakeMin={stakeMin || 0}
+                  EstimatedSessionLength={props.estimated_session_length || ''}
                 />
               )}
 
@@ -1291,6 +1324,13 @@ function MobileView(props: CodingBountiesProps) {
                     completion_date={props.estimated_completion_date}
                     session_length={props.estimated_session_length}
                   />
+                  {featureFlags.staking && isStakable && (
+                    <SelfAssignButton
+                      onClick={() => setShowComingSoonModal(true)}
+                      stakeMin={stakeMin || 0}
+                      EstimatedSessionLength={props.estimated_session_length || ''}
+                    />
+                  )}
                   <div className="buttonSet">
                     <ButtonSet
                       githubShareAction={() => {
@@ -1889,6 +1929,13 @@ function MobileView(props: CodingBountiesProps) {
                   completion_date={props.estimated_completion_date}
                   session_length={props.estimated_session_length}
                 />
+                {featureFlags.staking && isStakable && (
+                  <SelfAssignButton
+                    onClick={() => setShowComingSoonModal(true)}
+                    stakeMin={stakeMin || 0}
+                    EstimatedSessionLength={props.estimated_session_length || ''}
+                  />
+                )}
                 <ButtonSet
                   showGithubBtn={!!ticket_url}
                   githubShareAction={() => {
@@ -1979,6 +2026,13 @@ function MobileView(props: CodingBountiesProps) {
                   completion_date={props.estimated_completion_date}
                   session_length={props.estimated_session_length}
                 />
+                {featureFlags.staking && isStakable && (
+                  <SelfAssignButton
+                    onClick={() => setShowComingSoonModal(true)}
+                    stakeMin={stakeMin || 0}
+                    EstimatedSessionLength={props.estimated_session_length || ''}
+                  />
+                )}
                 <ButtonSet
                   showGithubBtn={!!ticket_url}
                   githubShareAction={() => {
@@ -2001,6 +2055,61 @@ function MobileView(props: CodingBountiesProps) {
             )}
           </AssigneeProfile>
         </NormalUser>
+      )}
+      {showComingSoonModal && (
+        <Modal
+          visible={true}
+          envStyle={{
+            borderRadius: '12px',
+            background: color.pureWhite,
+            padding: '32px 24px',
+            width: '400px',
+            maxWidth: '90vw',
+            boxShadow: '0px 8px 24px rgba(0, 0, 0, 0.1)'
+          }}
+          bigCloseImage={() => setShowComingSoonModal(false)}
+          bigCloseImageStyle={{
+            top: '-12px',
+            right: '-12px',
+            background: color.pureWhite,
+            borderRadius: '50%',
+            boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+            padding: '4px'
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              textAlign: 'center',
+              gap: '16px'
+            }}
+          >
+            <EuiText
+              style={{
+                fontSize: '24px',
+                fontWeight: 600,
+                color: color.grayish.G100,
+                marginBottom: '8px'
+              }}
+            >
+              Staking Coming Soon!
+            </EuiText>
+            <Button
+              color="primary"
+              onClick={() => setShowComingSoonModal(false)}
+              text="Got It!"
+              style={{
+                width: '120px',
+                height: '40px',
+                fontSize: '16px',
+                fontWeight: 600,
+                borderRadius: '8px'
+              }}
+            />
+          </div>
+        </Modal>
       )}
       <EuiGlobalToastList toasts={toasts} dismissToast={removeToast} toastLifeTimeMs={6000} />
     </div>

--- a/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
@@ -124,8 +124,8 @@ function MobileView(props: CodingBountiesProps) {
     completed,
     payment_failed,
     payment_pending,
-    stakeMin,
-    isStakable
+    stake_min,
+    is_stakable
   } = props;
   const color = colors['light'];
 
@@ -740,8 +740,6 @@ function MobileView(props: CodingBountiesProps) {
     fetchFeatureFlags();
   }, [main]);
 
-  console.log(featureFlags);
-
   if (isMobile) {
     return (
       <CodingMobile
@@ -872,10 +870,10 @@ function MobileView(props: CodingBountiesProps) {
                 />
               )}
 
-              {featureFlags.staking && isStakable && (
+              {featureFlags.staking && is_stakable && (
                 <SelfAssignButton
                   onClick={() => setShowComingSoonModal(true)}
-                  stakeMin={stakeMin || 0}
+                  stakeMin={stake_min || 0}
                   EstimatedSessionLength={props.estimated_session_length || ''}
                 />
               )}
@@ -1324,10 +1322,10 @@ function MobileView(props: CodingBountiesProps) {
                     completion_date={props.estimated_completion_date}
                     session_length={props.estimated_session_length}
                   />
-                  {featureFlags.staking && isStakable && (
+                  {featureFlags.staking && is_stakable && (
                     <SelfAssignButton
                       onClick={() => setShowComingSoonModal(true)}
-                      stakeMin={stakeMin || 0}
+                      stakeMin={stake_min || 0}
                       EstimatedSessionLength={props.estimated_session_length || ''}
                     />
                   )}
@@ -1929,10 +1927,10 @@ function MobileView(props: CodingBountiesProps) {
                   completion_date={props.estimated_completion_date}
                   session_length={props.estimated_session_length}
                 />
-                {featureFlags.staking && isStakable && (
+                {featureFlags.staking && is_stakable && (
                   <SelfAssignButton
                     onClick={() => setShowComingSoonModal(true)}
-                    stakeMin={stakeMin || 0}
+                    stakeMin={stake_min || 0}
                     EstimatedSessionLength={props.estimated_session_length || ''}
                   />
                 )}
@@ -2026,10 +2024,10 @@ function MobileView(props: CodingBountiesProps) {
                   completion_date={props.estimated_completion_date}
                   session_length={props.estimated_session_length}
                 />
-                {featureFlags.staking && isStakable && (
+                {featureFlags.staking && is_stakable && (
                   <SelfAssignButton
                     onClick={() => setShowComingSoonModal(true)}
-                    stakeMin={stakeMin || 0}
+                    stakeMin={stake_min || 0}
                     EstimatedSessionLength={props.estimated_session_length || ''}
                   />
                 )}

--- a/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
@@ -419,7 +419,7 @@ function MobileView(props: CodingBountiesProps) {
 
   const makePayment = async () => {
     setPaymentLoading(true);
-    // If the bounty has a commitment fee, add the fee to the user payment
+    // If the bounty has a commitment fee, add the fee to the user's payment
     const price = Number(props.price);
     // if there is an workspace and the workspace's
     // buudget is sufficient keysend to the user immediately

--- a/src/people/widgetViews/summaries/wantedSummaries/Components.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/Components.tsx
@@ -272,3 +272,64 @@ export const ICanHelpButton = ({ onClick }: ICanHelpButtonProps) => {
     />
   );
 };
+
+type SelfAssignButtonProps = {
+  onClick: () => void;
+  stakeMin: number;
+  EstimatedSessionLength: string;
+};
+
+export const SelfAssignButton = ({
+  onClick,
+  stakeMin,
+  EstimatedSessionLength
+}: SelfAssignButtonProps) => {
+  const color = colors['light'];
+
+  return (
+    <div style={{ width: '100%', marginTop: '16px' }}>
+      <IconButton
+        text={'Self Assign'}
+        endingIcon={'arrow_forward'}
+        width={'100%'}
+        height={48}
+        onClick={onClick}
+        color="primary"
+        hovercolor={color.button_secondary.hover}
+        activecolor={color.button_secondary.active}
+        shadowcolor={color.button_secondary.shadow}
+        iconSize={'16px'}
+        iconStyle={{
+          top: '16px',
+          right: '14px'
+        }}
+        textStyle={{
+          width: '100%',
+          display: 'flex',
+          justifyContent: 'center',
+          fontFamily: 'Barlow'
+        }}
+      />
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          marginTop: 16,
+          marginBottom: 8
+        }}
+      >
+        <span style={{ fontSize: 12, color: color.grayish.G100 }}>
+          Deposit this amount to Self Assign
+        </span>
+        <span style={{ fontSize: 16, fontWeight: 600 }}>{stakeMin?.toLocaleString()} SAT</span>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <span style={{ fontSize: 12, color: color.grayish.G100 }}>Time to Complete</span>
+        <span style={{ fontSize: 16, fontWeight: 600 }}>{EstimatedSessionLength}</span>
+      </div>
+    </div>
+  );
+};

--- a/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty */
 import '@testing-library/jest-dom';
 import {
   fireEvent,
@@ -18,6 +19,9 @@ import MobileView from '../CodingBounty';
 
 jest.mock('remark-gfm', () => ({}));
 
+jest.mock('rehype-raw', () => ({}));
+
+jest.mock('remark-gfm', () => ({}));
 jest.mock('rehype-raw', () => ({}));
 
 describe('MobileView component', () => {
@@ -514,5 +518,47 @@ describe('MobileView component', () => {
         expect(screen.getByText(defaultProps.titleString)).toBeInTheDocument();
       });
     })();
+  });
+
+  it('does not render Self Assignment Component when isStakable is false', async () => {
+    const mockGetFeatureFlags = jest.spyOn(mainStore, 'getFeatureFlags').mockResolvedValue({
+      success: true,
+      data: [{ name: 'staking', enabled: true }]
+    });
+
+    const props = {
+      ...defaultProps,
+      isStakable: false,
+      stakeMin: 1000
+    };
+
+    render(<MobileView {...props} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Self Assign')).not.toBeInTheDocument();
+    });
+
+    mockGetFeatureFlags.mockRestore();
+  });
+
+  it('does not render Self Assignment Component when staking feature flag is false', async () => {
+    const mockGetFeatureFlags = jest.spyOn(mainStore, 'getFeatureFlags').mockResolvedValue({
+      success: true,
+      data: [{ name: 'staking', enabled: false }]
+    });
+
+    const props = {
+      ...defaultProps,
+      isStakable: true,
+      stakeMin: 1000
+    };
+
+    render(<MobileView {...props} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Self Assign')).not.toBeInTheDocument();
+    });
+
+    mockGetFeatureFlags.mockRestore();
   });
 });

--- a/src/people/widgetViews/summaries/wantedSummaries/__tests__/Components.spec.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/__tests__/Components.spec.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { ViewTribe } from '../Components.tsx';
+import { SelfAssignButton, ViewTribe } from '../Components.tsx';
 // import { ViewTribe } from '../summaries/wantedSummaries/Components.tsx';
+
+jest.mock('remark-gfm', () => ({}));
+jest.mock('rehype-raw', () => ({}));
 
 describe('ViewTribe Component', () => {
   it('should display the tribe button enabled when a valid tribe is associated', () => {
@@ -39,5 +42,49 @@ describe('ViewTribe Component', () => {
     expect(screen.getByText('View Tribe')).toBeInTheDocument();
     expect(screen.getByRole('button')).toHaveAttribute('disabled');
     expect(screen.getByRole('button')).toHaveStyle('opacity: 0.5');
+  });
+});
+
+describe('SelfAssignButton Component', () => {
+  const mockOnClick = jest.fn();
+
+  it('renders with valid stake and session length', () => {
+    const mockProps = {
+      onClick: mockOnClick,
+      stakeMin: 5000,
+      EstimatedSessionLength: '2 hours'
+    };
+
+    render(<SelfAssignButton {...mockProps} />);
+
+    expect(screen.getByText('Self Assign')).toBeInTheDocument();
+    expect(screen.getByRole('button')).not.toHaveAttribute('disabled');
+    expect(screen.getByText('Deposit this amount to Self Assign')).toBeInTheDocument();
+    expect(screen.getByText('5,000 SAT')).toBeInTheDocument();
+    expect(screen.getByText('Time to Complete')).toBeInTheDocument();
+    expect(screen.getByText('2 hours')).toBeInTheDocument();
+  });
+
+  it('handles zero stake amount', () => {
+    const mockProps = {
+      onClick: mockOnClick,
+      stakeMin: 0,
+      EstimatedSessionLength: '30 minutes'
+    };
+
+    render(<SelfAssignButton {...mockProps} />);
+    expect(screen.getByText('0 SAT')).toBeInTheDocument();
+  });
+
+  it('handles missing session length', () => {
+    const mockProps = {
+      onClick: mockOnClick,
+      stakeMin: 1000,
+      EstimatedSessionLength: ''
+    };
+
+    render(<SelfAssignButton {...mockProps} />);
+    const timeElement = screen.getByText('Time to Complete').nextElementSibling;
+    expect(timeElement).toHaveTextContent('');
   });
 });


### PR DESCRIPTION
## Describe your changes
Enhance the Bounty Modal by integrating a Self Assignment Component specifically for stakeable bounties. This feature will improve user interaction by allowing users to assign bounties that are available when they know they can complete the work within the time allotted.

[Screencast from 2025-04-05 22-58-45.webm](https://github.com/user-attachments/assets/7f8bf26f-f048-4dbb-80b3-5bce7be5f077)

## Issue ticket number and link
https://community.sphinx.chat/bounty/4192/

## Type of change

- [X] New feature (non-breaking change which adds functionality)



## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested on Chrome and Firefox
- [X] I have tested on a mobile device
- [X] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend