### PR TITLE
Fix: 404 Error When Opening Draft Ticket in New Tab

### DIFF
--- a/src/people/WorkSpacePlanner/index.tsx
+++ b/src/people/WorkSpacePlanner/index.tsx
@@ -283,11 +283,11 @@ const WorkspacePlanner = observer(() => {
     {}
   );
 
-  const handleCardClick = (bountyId: string, status?: BountyCardStatus, ticketGroup?: string) => {
+  const handleCardClick = (bountyId: string, status?: BountyCardStatus, ticket_uuid?: string) => {
     bountyCardStore.saveFilterState();
-    if (status === 'DRAFT' && ticketGroup) {
+    if (status === 'DRAFT' && ticket_uuid) {
       const ticketUrl = history.createHref({
-        pathname: `/workspace/${uuid}/ticket/${ticketGroup}`,
+        pathname: `/workspace/${uuid}/ticket/${ticket_uuid}`,
         state: { from: `/workspace/${uuid}/planner` }
       });
       console.log('Opening ticket URL:', ticketUrl);
@@ -353,7 +353,7 @@ const WorkspacePlanner = observer(() => {
                         <BountyCardComp
                           key={card.id}
                           {...card}
-                          onclick={() => handleCardClick(card.id, card.status, card.ticket_group)}
+                          onclick={() => handleCardClick(card.id, card.status, card.ticket_uuid)}
                         />
                       ))
                   )}


### PR DESCRIPTION
## **Describe the bug**
- When clicking on a draft ticket, it opens in a new tab as expected. However, the `TicketEditor` component fails to load the ticket data, and instead displays the message: `"Ticket not found"`.
- As shown in the screenshot, the draft ticket URL is loaded, but the ticket content is not rendered.
- Show `404` Error

## Closed: #1421 

## Bounty Link:

- https://community.sphinx.chat/p/csfokk2tu2rulqj5lff0/assigned/4228/0

## Issue ticket number and link

- https://github.com/stakwork/sphinx-tribes-frontend/issues/1421

## Demo:

https://www.loom.com/share/55a83874baf14f319c65fbf7bf8ee3d1

## **Expected behavior**
- The draft ticket data should be correctly fetched and loaded into the `TicketEditor`.
- The message `Ticket not found` should only appear when a ticket genuinely doesn’t exist.

### Acceptance Criteria
- [x] Clicking a draft ticket loads the correct ticket data in the editor.
- [x] The “Ticket not found” message only appears for truly invalid or deleted ticket IDs.
- [x]  The fix has been tested on Chrome (desktop & mobile).
- [x] I have posted a screenshot or video in my PR
- [x] I have rebased and tested locally before submitting my PR