### PR TITLE
replace deprecated jsxBracketSameLine with bracketSameLine

### DIFF
--- a/prettier.json
+++ b/prettier.json
@@ -4,5 +4,5 @@
   "printWidth": 100,
   "singleQuote": true,
   "trailingComma": "none",
-  "jsxBracketSameLine": true
+  "bracketSameLine": true
 }


### PR DESCRIPTION
### Summary

Replaced deprecated `jsxBracketSameLine` with `bracketSameLine` in Prettier config to ensure compatibility with Prettier 3.0.3.
