### PR TITLE
Tribes frontend bounty navigate

### DIFF
--- a/src/pages/people/tabs/Wanted.tsx
+++ b/src/pages/people/tabs/Wanted.tsx
@@ -8,7 +8,7 @@ import { PostBounty } from 'people/widgetViews/postBounty';
 import WantedView from 'people/widgetViews/WantedView';
 import PageLoadSpinner from 'people/utils/PageLoadSpinner';
 import React, { useCallback, useEffect, useState } from 'react';
-import { Route, Switch, useHistory, useRouteMatch, useParams } from 'react-router-dom';
+import { Route, Switch, useRouteMatch, useParams } from 'react-router-dom';
 import { useStores } from 'store';
 import { paginationQueryLimit } from 'store/interface';
 import styled from 'styled-components';
@@ -91,7 +91,6 @@ export const Wanted = observer(() => {
   const { ui, main } = useStores();
   const { person, canEdit } = usePerson(ui.selectedPerson);
   const { path, url } = useRouteMatch();
-  const history = useHistory();
   const { uuid } = useParams<{ uuid: string }>();
   const [displayedBounties, setDisplayedBounties] = useState<BountyType[]>([]);
   const [loading, setIsLoading] = useState<boolean>(false);
@@ -164,18 +163,16 @@ export const Wanted = observer(() => {
       </Switch>
       {displayedBounties
         .filter((w: BountyType) => w.body.owner_id === person?.owner_pubkey)
-        .map((w: BountyType, i: any) => (
+        .map((w: BountyType) => (
           <Panel
-            href={`${url}/${w.body.id}/${i}`}
+            href={`/bounty/${w.body.id}`}
             key={w.body.id}
             data-testid={'user-created-bounty'}
             isMobile={false}
             onClick={(e: any) => {
               e.preventDefault();
               ui.setBountyPerson(person?.id);
-              history.push({
-                pathname: `${url}/${w.body.id}/${i}`
-              });
+              window.open(`/bounty/${w.body.id}`, '_blank');
             }}
           >
             <WantedView {...w.body} person={person} />

--- a/src/people/widgetViews/UserTicketsView.tsx
+++ b/src/people/widgetViews/UserTicketsView.tsx
@@ -78,10 +78,8 @@ const UserTickets = () => {
     setCheckboxIdToSelectedMap({ ...defaultStatus, [id]: !checkboxIdToSelectedMap[id] });
   };
 
-  function onPanelClick(id: number, index: number) {
-    history.push({
-      pathname: `${url}/${id}/${index}`
-    });
+  function onPanelClick(id: number) {
+    window.open(`/bounty/${id}`, '_blank');
   }
 
   const deleteTicket = async (payload: any) => {
@@ -152,7 +150,7 @@ const UserTickets = () => {
         const body = { ...item.body };
         return (
           <Panel
-            href={`${url}/${body.id}/${i}`}
+            href={`/bounty/${body.id}`}
             isMobile={isMobile}
             key={i + body?.created}
             data-testid={'user-personal-bounty-card'}
@@ -162,7 +160,7 @@ const UserTickets = () => {
               showName
               onPanelClick={(e: any) => {
                 e.preventDefault();
-                onPanelClick(body.id, i);
+                onPanelClick(body.id);
                 ui.setBountyPerson(person?.id);
                 setBountyOwner(person);
               }}


### PR DESCRIPTION
## Describe your changes
https://www.loom.com/share/3f4ded209c124b72b331f23ebbb24db7?sid=8b71b650-fba2-42f8-a134-fa8839f6e6b8

This PR updates bounty links to open the public bounty page (/bounty/:id) in a new tab instead of navigating to internal routes like /p/.../bounties/:id/:index.

    Updated hrefs and onClick handlers to use window.open('/bounty/:id', '_blank')

    Replaced history.push in onPanelClick with window.open

Why:

Users were sharing internal links by copying the URL from their address bar. To ensure consistent, shareable links, we now open the clean public route in a new tab. This improves UX and avoids sharing private or nested URLs.

## Issue ticket number and link 
https://community.sphinx.chat/bounty/4257

## Type of change

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested on Chrome and Firefox
- [X] I have tested on a mobile device
- [X] I have provided a screenshot or recording of changes in my PR if there were updates to the frontend