### PR TITLE
Modify URL link behavior to open in new tab

### DIFF
--- a/src/people/utils/RenderMarkdown.tsx
+++ b/src/people/utils/RenderMarkdown.tsx
@@ -156,6 +156,18 @@ export function renderMarkdown(markdown: any, customStyles?: CustomStyles) {
               </pre>
             );
           },
+          a({ className, children, ...props }: any) {
+            return (
+              <a
+                className={className}
+                target="_blank"
+                rel="noopener noreferrer"
+                {...props}
+              >
+                {children}
+              </a>
+            );
+          },
           img({ className, ...props }: any) {
             return (
               <img


### PR DESCRIPTION
## Goal

Tapping any URL link inside Hive Chat should open a new tab.