### PR TITLE
Fix the crashing chatting section

### DIFF
--- a/src/people/hiveChat/ActionArtifactRenderer.tsx
+++ b/src/people/hiveChat/ActionArtifactRenderer.tsx
@@ -177,14 +177,17 @@ export const ActionArtifactRenderer: React.FC<ActionArtifactRendererProps> = obs
             onMouseEnter={() => setHasInteracted(true)}
             onFocus={() => setHasInteracted(true)}
           >
-            {content.actionText &&
-              renderMarkdown(content.actionText, {
-                codeBlockBackground: '#282c34',
-                textColor: '#abb2bf',
-                bubbleTextColor: '',
-                borderColor: '#444',
-                codeBlockFont: 'Courier New'
-              })}
+            {content.actionText.trim() !== '' && (
+              <>
+                {renderMarkdown(content.actionText.trim(), {
+                  codeBlockBackground: '#282c34',
+                  textColor: '#abb2bf',
+                  bubbleTextColor: '',
+                  borderColor: '#444',
+                  codeBlockFont: 'Courier New'
+                })}
+              </>
+            )}
 
             <ActionButtons
               options={content.options}


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Error message:

![image](https://github.com/user-attachments/assets/3933dc94-2ad2-4257-9ec0-e10d80eaee3d)

## According to this error:

 The error shown in the image is:

Error: Minified React error #310
What it means:
This is a minified React error, which means React is throwing an error in production mode, and the actual descriptive error message has been shortened to save space.

Error #310:
Minified React error #310 typically occurs when React detects an invalid object passed as a React child, or when the expected component/element structure is broken.

How to debug:
You need to go to the full error message using the link provided in the console:

https://reactjs.org/docs/error-decoder.html?invariant=310
This URL will decode the minified error and give you a detailed explanation, especially if you include the additional arguments from the stack trace (if available).

Likely cause based on context:
From the file names (ActionCardRenderer.tsx:195), it's possible you're:

Passing a non-renderable value (like an object or undefined) to JSX.

Rendering something like {someObject} instead of safely formatting or stringifying it.



