### PR TITLE
Use public bounty links from profile cards

### DIFF
--- a/src/pages/people/tabs/Wanted.tsx
+++ b/src/pages/people/tabs/Wanted.tsx
@@ -8,7 +8,7 @@ import { PostBounty } from 'people/widgetViews/postBounty';
 import WantedView from 'people/widgetViews/WantedView';
 import PageLoadSpinner from 'people/utils/PageLoadSpinner';
 import React, { useCallback, useEffect, useState } from 'react';
-import { Route, Switch, useRouteMatch, useParams } from 'react-router-dom';
+import { Route, Switch, useRouteMatch, useParams, useHistory } from 'react-router-dom';
 import { useStores } from 'store';
 import { paginationQueryLimit } from 'store/interface';
 import styled from 'styled-components';
@@ -92,6 +92,7 @@ export const Wanted = observer(() => {
   const { person, canEdit } = usePerson(ui.selectedPerson);
   const { path, url } = useRouteMatch();
   const { uuid } = useParams<{ uuid: string }>();
+  const history = useHistory();
   const [displayedBounties, setDisplayedBounties] = useState<BountyType[]>([]);
   const [loading, setIsLoading] = useState<boolean>(false);
   const [page, setPage] = useState(1);
@@ -172,7 +173,7 @@ export const Wanted = observer(() => {
             onClick={(e: any) => {
               e.preventDefault();
               ui.setBountyPerson(person?.id);
-              window.open(`/bounty/${w.body.id}`, '_blank');
+              history.push(`/bounty/${w.body.id}`);
             }}
           >
             <WantedView {...w.body} person={person} />

--- a/src/pages/people/tabs/__tests__/Wanted.spec.tsx
+++ b/src/pages/people/tabs/__tests__/Wanted.spec.tsx
@@ -232,7 +232,7 @@ describe('Wanted Component', () => {
     });
   });
 
-  test('should redirect to bounty page when bounty card is clicked', async () => {
+  test('should use public bounty URL when bounty card is clicked', async () => {
     const mockPush = jest.fn();
 
     jest.mock('react-router-dom', () => ({
@@ -282,7 +282,7 @@ describe('Wanted Component', () => {
       getAllByTestId('user-created-bounty')[0].click();
       expect(getAllByTestId('user-created-bounty').length).toBe(1);
       expect(getAllByTestId('user-created-bounty')[0].getAttribute('href')).toEqual(
-        `/p/1234/wanted/${userBounty.body.id}/0`
+        `/bounty/${userBounty.body.id}`
       );
     });
   });


### PR DESCRIPTION
## Summary

- Route bounty cards from a user profile's Bounties tab to the public bounty URL.
- Replace the profile-tab/new-window navigation with `history.push('/bounty/{id}')`.
- Update the existing Wanted tab regression test to assert the public bounty URL.

## Issue

Fixes #1489

## Verification

- `env REACT_APP_IS_TEST=true NODE_ENV=test https_proxy=http://127.0.0.1:1080 http_proxy=http://127.0.0.1:1080 all_proxy=socks5://127.0.0.1:1080 corepack yarn jest src/pages/people/tabs/__tests__/Wanted.spec.tsx --runInBand --no-cache --coverage=false --testNamePattern='should use public bounty URL'`

The issue-specific Jest assertion passes and exits 0:

- `PASS src/pages/people/tabs/__tests__/Wanted.spec.tsx`
- `should use public bounty URL when bounty card is clicked`

I also ran the full affected spec file with the same env flags. Jest reported `13 passed`, but the command exited 1 because existing async tests log after completion and hit unmocked Nock requests.

## Bounty

This PR addresses the Bounties-labeled issue:

https://github.com/stakwork/sphinx-tribes-frontend/issues/1489

BTC wallet for bounty payout:

`bc1p2qljd23y9dtn976ftemlpp9cnm66nnkk89gx4xdw4fg63cpmchjsx8uf6r`
