### PR TITLE
Use delete modal for activity removal

### DIFF
--- a/src/people/widgetViews/workspace/Activities/Activities.test.tsx
+++ b/src/people/widgetViews/workspace/Activities/Activities.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { render, fireEvent, waitFor, within } from '@testing-library/react';
 import { useStores } from 'store';
+import { activityStore } from 'store/activityStore';
 import { useHistory, useParams } from 'react-router-dom';
+import { useDeleteConfirmationModal } from 'components/common';
 import { createAndNavigateToHivechat } from '../../../../utils/hivechatUtils';
 import Activities from './Activities';
 
@@ -9,8 +12,50 @@ jest.mock('../../../../utils/hivechatUtils', () => ({
   createAndNavigateToHivechat: jest.fn()
 }));
 
+jest.mock(
+  'components/common/SidebarComponent',
+  () =>
+    function MockSidebarComponent() {
+      return <div data-testid="sidebar" />;
+    }
+);
+
+jest.mock('people/utils/RenderMarkdown', () => ({
+  renderMarkdown: (content: string) => content
+}));
+
+jest.mock(
+  './header',
+  () =>
+    function MockActivitiesHeader() {
+      return <div data-testid="activities-header" />;
+    }
+);
+
+jest.mock('remark-gfm', () => null);
+
+jest.mock('rehype-raw', () => null);
+
 jest.mock('store', () => ({
   useStores: jest.fn()
+}));
+
+jest.mock('store/activityStore', () => ({
+  activityStore: {
+    rootActivities: [],
+    fetchWorkspaceActivities: jest.fn().mockResolvedValue(true),
+    getActivity: jest.fn(),
+    getThreadResponses: jest.fn().mockReturnValue([]),
+    createActivity: jest.fn(),
+    createThreadResponse: jest.fn(),
+    updateActivity: jest.fn(),
+    deleteActivity: jest.fn().mockResolvedValue(true)
+  }
+}));
+
+jest.mock('components/common', () => ({
+  ...jest.requireActual('components/common'),
+  useDeleteConfirmationModal: jest.fn()
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -23,105 +68,157 @@ describe('Activities', () => {
     createChat: jest.fn()
   };
 
+  const mockMain = {
+    getWorkspaceFeatures: jest.fn().mockResolvedValue([]),
+    getFeaturePhases: jest.fn().mockResolvedValue([]),
+    getUserWorkspaceByUuid: jest.fn().mockResolvedValue({ owner_pubkey: 'owner-pubkey' }),
+    getUserRoles: jest.fn().mockResolvedValue([]),
+    bountyRoles: []
+  };
+
   const mockUI = {
     setToasts: jest.fn(),
-    meInfo: { owner_alias: 'TestUser' }
+    meInfo: { owner_alias: 'TestUser', owner_pubkey: 'owner-pubkey' },
+    _meInfo: { owner_alias: 'TestUser', owner_pubkey: 'owner-pubkey' }
   };
 
   const mockHistory = {
     push: jest.fn()
   };
 
-  const mockActivityStore = {
-    rootActivities: [
-      {
-        ID: '123',
-        title: 'Test Feature Activity',
-        content: 'This is test content for the feature activity',
-        content_type: 'feature_creation',
-        workspace: 'workspace-uuid',
-        time_created: '2023-01-01T00:00:00Z'
-      },
-      {
-        ID: '456',
-        title: 'Non-Feature Activity',
-        content: 'This is a general update',
-        content_type: 'general_update',
-        workspace: 'workspace-uuid',
-        time_created: '2023-01-02T00:00:00Z'
-      }
-    ],
-    loadActivities: jest.fn().mockResolvedValue(true),
-    getActivity: jest
-      .fn()
-      .mockImplementation((id) => mockActivityStore.rootActivities.find((a) => a.ID === id))
-  };
+  const mockOpenDeleteConfirmation = jest.fn();
+
+  const activities = [
+    {
+      id: '123',
+      ID: '123',
+      title: 'Test Feature Activity',
+      content: 'This is test content for the feature activity',
+      content_type: 'feature_creation',
+      workspace: 'workspace-uuid',
+      time_created: '2023-01-01T00:00:00Z'
+    },
+    {
+      id: '456',
+      ID: '456',
+      title: 'Non-Feature Activity',
+      content: 'This is a general update',
+      content_type: 'general_update',
+      workspace: 'workspace-uuid',
+      time_created: '2023-01-02T00:00:00Z'
+    }
+  ];
 
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.assign(activityStore, {
+      rootActivities: activities,
+      fetchWorkspaceActivities: jest.fn().mockResolvedValue(true),
+      getActivity: jest.fn().mockImplementation((id) => activities.find((a) => a.ID === id)),
+      getThreadResponses: jest.fn().mockReturnValue([]),
+      deleteActivity: jest.fn().mockResolvedValue(true)
+    });
     (useStores as jest.Mock).mockReturnValue({
+      main: mockMain,
       chat: mockChat,
-      ui: mockUI,
-      activityStore: mockActivityStore
+      ui: mockUI
     });
     (useHistory as jest.Mock).mockReturnValue(mockHistory);
     (useParams as jest.Mock).mockReturnValue({ uuid: 'workspace-uuid' });
+    (useDeleteConfirmationModal as jest.Mock).mockReturnValue({
+      openDeleteConfirmation: mockOpenDeleteConfirmation
+    });
 
     (createAndNavigateToHivechat as jest.Mock).mockResolvedValue(true);
   });
 
   test('renders Build with Hivechat button for feature_creation content type', async () => {
-    waitFor(() => {
-      const { getByTestId, getAllByTestId } = render(<Activities />);
+    const { getByTestId, getAllByTestId } = render(<Activities />);
 
-      expect(mockActivityStore.loadActivities).toHaveBeenCalled();
-
-      const activityItems = getAllByTestId('touch-target');
-      fireEvent.click(activityItems[0]);
-
-      const detailsPanel = getByTestId('activity-details');
-      expect(detailsPanel).toBeInTheDocument();
-
-      const buildButton = getByTestId('build-with-hivechat-btn');
-      expect(buildButton).toBeInTheDocument();
-      expect(buildButton.textContent).toBe('Build with Hivechat');
+    await waitFor(() => {
+      expect(activityStore.fetchWorkspaceActivities).toHaveBeenCalled();
     });
+    await waitFor(() => {
+      expect(activityStore.getThreadResponses).toHaveBeenCalled();
+    });
+
+    const activityItems = getAllByTestId('touch-target');
+    fireEvent.click(activityItems[0]);
+
+    const detailsPanel = getByTestId('activity-details');
+    expect(detailsPanel).toBeInTheDocument();
+
+    const buildButton = getByTestId('build-with-hivechat-btn');
+    expect(buildButton).toBeInTheDocument();
+    expect(buildButton.textContent).toBe('Build with Hivechat');
   });
 
   test('does not render Build with Hivechat button for non-feature_creation content types', async () => {
-    waitFor(() => {
-      const { queryByTestId, getAllByTestId } = render(<Activities />);
+    const { queryByTestId, getAllByTestId } = render(<Activities />);
 
-      expect(mockActivityStore.loadActivities).toHaveBeenCalled();
-
-      const activityItems = getAllByTestId('touch-target');
-      fireEvent.click(activityItems[1]);
-
-      const buildButton = queryByTestId('build-with-hivechat-btn');
-      expect(buildButton).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(activityStore.fetchWorkspaceActivities).toHaveBeenCalled();
     });
+    await waitFor(() => {
+      expect(activityStore.getThreadResponses).toHaveBeenCalled();
+    });
+
+    const activityItems = getAllByTestId('touch-target');
+    fireEvent.click(activityItems[1]);
+
+    const buildButton = queryByTestId('build-with-hivechat-btn');
+    expect(buildButton).not.toBeInTheDocument();
   });
 
   test('clicking Build with Hivechat button calls createAndNavigateToHivechat', async () => {
-    waitFor(() => {
-      const { getByTestId, getAllByTestId } = render(<Activities />);
+    const { getByTestId, getAllByTestId } = render(<Activities />);
 
-      expect(mockActivityStore.loadActivities).toHaveBeenCalled();
-
-      const activityItems = getAllByTestId('touch-target');
-      fireEvent.click(activityItems[0]);
-
-      const buildButton = getByTestId('build-with-hivechat-btn');
-      fireEvent.click(buildButton);
-
-      expect(createAndNavigateToHivechat).toHaveBeenCalledWith(
-        'workspace-uuid',
-        'Test Feature Activity',
-        'This is test content for the feature activity',
-        mockChat,
-        mockUI,
-        mockHistory
-      );
+    await waitFor(() => {
+      expect(activityStore.fetchWorkspaceActivities).toHaveBeenCalled();
     });
+    await waitFor(() => {
+      expect(activityStore.getThreadResponses).toHaveBeenCalled();
+    });
+
+    const activityItems = getAllByTestId('touch-target');
+    fireEvent.click(activityItems[0]);
+
+    const buildButton = getByTestId('build-with-hivechat-btn');
+    fireEvent.click(buildButton);
+
+    expect(createAndNavigateToHivechat).toHaveBeenCalledWith(
+      'workspace-uuid',
+      'Test Feature Activity',
+      'This is test content for the feature activity',
+      mockChat,
+      mockUI,
+      mockHistory
+    );
+  });
+
+  test('clicking Delete opens delete confirmation modal', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm');
+
+    const { getByTestId, getAllByTestId } = render(<Activities />);
+
+    await waitFor(() => {
+      expect(activityStore.fetchWorkspaceActivities).toHaveBeenCalledWith('workspace-uuid');
+    });
+    await waitFor(() => {
+      expect(activityStore.getThreadResponses).toHaveBeenCalled();
+    });
+
+    fireEvent.click(getAllByTestId('touch-target')[0]);
+    fireEvent.click(within(getByTestId('activity-details-buttons')).getByText('Delete'));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(mockOpenDeleteConfirmation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onDelete: expect.any(Function),
+        children: expect.anything()
+      })
+    );
+
+    confirmSpy.mockRestore();
   });
 });

--- a/src/people/widgetViews/workspace/Activities/Activities.tsx
+++ b/src/people/widgetViews/workspace/Activities/Activities.tsx
@@ -12,6 +12,7 @@ import { useStores } from 'store';
 import { useParams, useHistory } from 'react-router-dom';
 import { renderMarkdown } from 'people/utils/RenderMarkdown';
 import SidebarComponent from 'components/common/SidebarComponent';
+import { useDeleteConfirmationModal } from 'components/common';
 import { Body } from 'pages/tickets/style';
 import { Phase, Toast } from '../interface';
 import { FullNoBudgetWrap, FullNoBudgetText } from '../style';
@@ -415,6 +416,7 @@ const Activities = observer(() => {
   const [activityPreviewMode, setActivityPreviewMode] = useState<'preview' | 'edit'>('preview');
   const [editedContent, setEditedContent] = useState('');
   const [toasts, setToasts] = useState<Toast[]>([]);
+  const { openDeleteConfirmation } = useDeleteConfirmationModal();
 
   let interval: NodeJS.Timeout | number | null = null;
 
@@ -675,23 +677,44 @@ const Activities = observer(() => {
     }
   };
 
-  const handleDeleteActivity = async (activityId: string) => {
-    if (window.confirm('Are you sure you want to delete this activity?')) {
-      try {
-        const success = await activityStore.deleteActivity(activityId);
-        if (success) {
-          if (selectedActivity?.ID === activityId) {
-            setSelectedActivity(null);
-          }
-          await activityStore.fetchWorkspaceActivities(uuid);
-        } else {
-          alert('Failed to delete activity');
-        }
-      } catch (error) {
-        console.error('Error deleting activity:', error);
-        alert('Failed to delete activity');
+  const addActivityToast = (title: string, text: string, color: Toast['color']) => {
+    setToasts([
+      {
+        id: `${Date.now()}-activity-delete`,
+        title,
+        color,
+        text
       }
+    ]);
+  };
+
+  const deleteActivity = async (activityId: string) => {
+    try {
+      const success = await activityStore.deleteActivity(activityId);
+      if (success) {
+        if (selectedActivity?.ID === activityId) {
+          setSelectedActivity(null);
+        }
+        await activityStore.fetchWorkspaceActivities(uuid);
+        addActivityToast('Success', 'Activity deleted successfully', 'success');
+      } else {
+        addActivityToast('Error', 'Failed to delete activity', 'danger');
+      }
+    } catch (error) {
+      console.error('Error deleting activity:', error);
+      addActivityToast('Error', 'Failed to delete activity', 'danger');
     }
+  };
+
+  const handleDeleteActivity = (activityId: string) => {
+    openDeleteConfirmation({
+      onDelete: () => deleteActivity(activityId),
+      children: (
+        <div style={{ fontSize: 20, textAlign: 'center' }}>
+          Are you sure you want to delete this activity?
+        </div>
+      )
+    });
   };
 
   const removeItem = (field: 'actions' | 'questions', index: number) => {


### PR DESCRIPTION
## Summary

- Replace the activity delete browser confirmation with the shared delete confirmation modal.
- Add success and failure toast messages for activity deletion.
- Update the Activities tests to cover the delete modal flow and clean up the existing async test setup.

## Issue

Fixes #1434

## Verification

- `env REACT_APP_IS_TEST=true NODE_ENV=test https_proxy=http://127.0.0.1:1080 http_proxy=http://127.0.0.1:1080 all_proxy=socks5://127.0.0.1:1080 corepack yarn jest src/people/widgetViews/workspace/Activities/Activities.test.tsx --runInBand --no-cache --coverage=false`
- `env REACT_APP_IS_TEST=true NODE_ENV=test https_proxy=http://127.0.0.1:1080 http_proxy=http://127.0.0.1:1080 all_proxy=socks5://127.0.0.1:1080 corepack yarn eslint src/people/widgetViews/workspace/Activities/Activities.tsx src/people/widgetViews/workspace/Activities/Activities.test.tsx`

## Bounty

This PR addresses the Bounties-labeled issue:

https://github.com/stakwork/sphinx-tribes-frontend/issues/1434

BTC wallet for bounty payout:

`bc1p2qljd23y9dtn976ftemlpp9cnm66nnkk89gx4xdw4fg63cpmchjsx8uf6r`
