### PR TITLE
Enable workspace image changes to save

### DIFF
--- a/src/people/widgetViews/__tests__/EditOrgModal.spec.tsx
+++ b/src/people/widgetViews/__tests__/EditOrgModal.spec.tsx
@@ -9,6 +9,10 @@ jest.mock('../../../store', () => ({
   useStores: jest.fn()
 }));
 
+jest.mock('remark-gfm', () => null);
+
+jest.mock('rehype-raw', () => null);
+
 const mockUpdateWorkspace = jest.fn();
 const mockAddToast = jest.fn();
 
@@ -30,7 +34,7 @@ const mockWorkspace: Workspace = {
 };
 
 const props = {
-  ...mockWorkspace,
+  org: mockWorkspace,
   isOpen: true,
   onDelete: () => null,
   resetWorkspace: () => null,
@@ -41,10 +45,12 @@ const props = {
 beforeEach(() => {
   mockUpdateWorkspace.mockReset();
   mockAddToast.mockReset();
+  URL.createObjectURL = jest.fn(() => 'blob:workspace-logo-preview');
 
   (useStores as jest.Mock).mockReturnValue({
     main: {
-      updateWorkspace: mockUpdateWorkspace
+      updateWorkspace: mockUpdateWorkspace,
+      uploadFile: jest.fn()
     },
     ui: {
       meInfo: { owner_pubkey: 'xyz456' }
@@ -86,6 +92,26 @@ describe('EditWorkspaceModal Component', () => {
   test('displays the Delete button', () => {
     render(<EditWorkspaceModal {...props} />);
     expect(screen.getByText(/Delete Workspace/i)).toBeInTheDocument();
+  });
+
+  test('enables Save changes when only the organization image is updated', async () => {
+    render(<EditWorkspaceModal {...props} />);
+
+    const saveChangesButton = screen.getByText('Save changes').closest('button');
+    expect(saveChangesButton).toBeDisabled();
+
+    const fileInput = document.querySelector('#file-input') as HTMLInputElement;
+    const imageFile = new File(['logo'], 'logo.png', { type: 'image/png' });
+
+    fireEvent.change(fileInput, {
+      target: {
+        files: [imageFile]
+      }
+    });
+
+    await waitFor(() => {
+      expect(saveChangesButton).toBeEnabled();
+    });
   });
 
   test('Save button is enabled if name have a value, and website, github, logo, description are empty', async () => {

--- a/src/people/widgetViews/workspace/EditWorkspaceModal.tsx
+++ b/src/people/widgetViews/workspace/EditWorkspaceModal.tsx
@@ -185,6 +185,7 @@ const EditWorkspaceModal = (props: EditWorkspaceModalProps) => {
   };
   const [selectedImage, setSelectedImage] = useState<string>(org?.img || '');
   const [rawSelectedFile, setRawSelectedFile] = useState<File | null>(null);
+  const [imageChanged, setImageChanged] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleColor = (data: any, value: string) => {
@@ -205,15 +206,7 @@ const EditWorkspaceModal = (props: EditWorkspaceModalProps) => {
       let img = '';
       const formData = new FormData();
       if (rawSelectedFile) {
-        console.log('rawSelectedFile:', {
-          name: rawSelectedFile.name,
-          size: rawSelectedFile.size,
-          type: rawSelectedFile.type,
-          lastModified: rawSelectedFile.lastModified
-        });
-        console.log('selectedImage:', selectedImage);
         formData.append('file', rawSelectedFile);
-        console.log('Form Data:', Object.fromEntries(formData));
         const file = await main.uploadFile(formData);
         if (file && file.ok) {
           img = await file.json();
@@ -255,37 +248,28 @@ const EditWorkspaceModal = (props: EditWorkspaceModalProps) => {
   const isWorkspaceAdmin = props.org?.owner_pubkey === ui.meInfo?.owner_pubkey;
 
   const handleFileInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    console.log('Event files:', e.target.files);
     const file = e.target.files && e.target.files[0];
     if (file) {
-      console.log('File:', {
-        name: file.name,
-        size: file.size,
-        type: file.type,
-        lastModified: file.lastModified
-      });
       // Display the selected image
       const imageUrl = URL.createObjectURL(file);
       setSelectedImage(imageUrl);
       setRawSelectedFile(file);
+      setImageChanged(true);
     } else {
       // Handle the case where the user cancels the file dialog
-      setSelectedImage('');
+      setSelectedImage(org?.img || '');
+      setRawSelectedFile(null);
+      setImageChanged(false);
     }
   };
   const handleDrop = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     const file = event.dataTransfer.files[0];
     if (file) {
-      console.log('File:', {
-        name: file.name,
-        size: file.size,
-        type: file.type,
-        lastModified: file.lastModified
-      });
       const imageUrl = URL.createObjectURL(file);
       setSelectedImage(imageUrl);
       setRawSelectedFile(file);
+      setImageChanged(true);
     }
   };
 
@@ -458,7 +442,7 @@ const EditWorkspaceModal = (props: EditWorkspaceModalProps) => {
                     </InputContainer>
                   ))}
                   <Button
-                    disabled={!values.name || !isValid || !dirty}
+                    disabled={!values.name || !isValid || (!dirty && !imageChanged)}
                     onClick={() => handleSubmit()}
                     loading={loading}
                     style={{
@@ -471,7 +455,9 @@ const EditWorkspaceModal = (props: EditWorkspaceModalProps) => {
                       top: '390px',
                       left: '527px'
                     }}
-                    color={!values.name || !isValid || !dirty ? 'gray' : 'primary'}
+                    color={
+                      !values.name || !isValid || (!dirty && !imageChanged) ? 'gray' : 'primary'
+                    }
                     text={'Save changes'}
                   />
                 </InputWrapper>


### PR DESCRIPTION
## Summary
- Enables Save changes when only the workspace logo image changes
- Resets the image-change state when the file picker is cancelled
- Removes debug logging from the workspace image upload path
- Adds a regression test for image-only workspace edits

Fixes #489.

## Verification
- `env REACT_APP_IS_TEST=true NODE_ENV=test https_proxy=http://127.0.0.1:1080 http_proxy=http://127.0.0.1:1080 all_proxy=socks5://127.0.0.1:1080 corepack yarn jest src/people/widgetViews/__tests__/EditOrgModal.spec.tsx --runInBand --no-cache --coverage=false`
- `env REACT_APP_IS_TEST=true NODE_ENV=test https_proxy=http://127.0.0.1:1080 http_proxy=http://127.0.0.1:1080 all_proxy=socks5://127.0.0.1:1080 corepack yarn eslint src/people/widgetViews/workspace/EditWorkspaceModal.tsx src/people/widgetViews/__tests__/EditOrgModal.spec.tsx`

## Bounty
Issue: https://github.com/stakwork/sphinx-tribes-frontend/issues/489

BTC wallet: `bc1p2qljd23y9dtn976ftemlpp9cnm66nnkk89gx4xdw4fg63cpmchjsx8uf6r`
