### PR TITLE
Add Cypress meme image upload helper

### DIFF
--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -7,6 +7,7 @@ declare namespace Cypress {
     create_workspace_bounty(workspaceBounty: Bounty): void;
     lnurl_login(seed?: string): Chainable<string>;
     create_workspace(Workspace: Workspace): void;
+    uploadImageToMemeServer(options?: MemeUploadOptions): Chainable<string>;
     pay_invoice(details: InvoiceDetail): void;
     add_invoice(details: AddInvoice): Promise<any>;
     clickAlias(userAlias: string): void;
@@ -52,6 +53,15 @@ declare namespace Cypress {
     website?: string;
     github?: string;
     feature_call?: string;
+  };
+
+  type MemeUploadOptions = {
+    base64?: string;
+    fileName?: string;
+    mimeType?: string;
+    tribesUrl?: string;
+    jwt?: string;
+    expectedStatus?: number;
   };
 
   type InvoiceDetail = {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -41,6 +41,71 @@ import { bech32 } from 'bech32';
 const EC = require('elliptic').ec;
 
 const v2AdminToken = 'xyzxyzxyz';
+const defaultTestImageBase64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+function parseMemeUploadResponse(responseText: string): string {
+  const parsed = JSON.parse(responseText);
+
+  if (typeof parsed === 'string') {
+    return parsed;
+  }
+
+  if (parsed && typeof parsed.url === 'string') {
+    return parsed.url;
+  }
+
+  throw new Error('Unexpected meme upload response');
+}
+
+Cypress.Commands.add('uploadImageToMemeServer', (options = {}) => {
+  const {
+    base64 = defaultTestImageBase64,
+    fileName = 'cypress-test-image.png',
+    mimeType = 'image/png',
+    tribesUrl = 'http://localhost:13000',
+    jwt,
+    expectedStatus = 200
+  } = options;
+
+  return cy.window().then((win) => {
+    const uploadJwt = jwt || win.localStorage.getItem('tribe_jwt') || '';
+    const byteCharacters = win.atob(base64);
+    const byteNumbers = new Array(byteCharacters.length);
+
+    for (let i = 0; i < byteCharacters.length; i++) {
+      byteNumbers[i] = byteCharacters.charCodeAt(i);
+    }
+
+    const blob = new win.Blob([new Uint8Array(byteNumbers)], { type: mimeType });
+    const formData = new win.FormData();
+    formData.append('file', blob, fileName);
+
+    return new Cypress.Promise<string>((resolve, reject) => {
+      const request = new win.XMLHttpRequest();
+      request.open('POST', `${tribesUrl}/meme_upload`);
+      if (uploadJwt) {
+        request.setRequestHeader('x-jwt', uploadJwt);
+      }
+
+      request.onload = () => {
+        if (request.status !== expectedStatus) {
+          reject(new Error(`Meme upload failed with status ${request.status}`));
+          return;
+        }
+
+        try {
+          resolve(parseMemeUploadResponse(request.responseText));
+        } catch (error) {
+          reject(error);
+        }
+      };
+
+      request.onerror = () => reject(new Error('Meme upload request failed'));
+      request.send(formData);
+    });
+  });
+});
 
 Cypress.Commands.add('login', (userAlias: string) => {
   let user;


### PR DESCRIPTION
## Summary
- Adds a reusable Cypress command for uploading a test image to the meme server
- Supports a default inline PNG plus custom image data, filename, mime type, JWT, URL, and expected status
- Adds Cypress typing for the new command so specs can use the uploaded image URL directly

Fixes #325.

## Verification
- `env REACT_APP_IS_TEST=true NODE_ENV=test https_proxy=http://127.0.0.1:1080 http_proxy=http://127.0.0.1:1080 all_proxy=socks5://127.0.0.1:1080 corepack yarn tsc --target es2015 --moduleResolution node --types cypress,node --lib es2015,dom --skipLibCheck --noEmit cypress/support/commands.ts cypress/global.d.ts`
- `./node_modules/.bin/prettier --config prettier.json --check cypress/support/commands.ts cypress/global.d.ts`

Note: `corepack yarn tsc -p cypress/tsconfig.json --noEmit` currently fails on existing Cypress project issues outside this patch, including missing local fixture JSON files, an existing `EstimateSessionLength` mismatch, dependency private identifier target errors, and an existing path alias resolution issue.

## Bounty
Issue: https://github.com/stakwork/sphinx-tribes-frontend/issues/325

BTC wallet: `bc1p2qljd23y9dtn976ftemlpp9cnm66nnkk89gx4xdw4fg63cpmchjsx8uf6r`
