### PR TITLE
Fix workspace bounty skill filter query

### DIFF
--- a/src/pages/tickets/__tests__/WorkspaceHeader.spec.tsx
+++ b/src/pages/tickets/__tests__/WorkspaceHeader.spec.tsx
@@ -140,6 +140,19 @@ describe('WorkspaceHeader Component', () => {
     });
   });
 
+  it('uses the API languages query key when the workspace skill filter is active', async () => {
+    render(<WorkspaceHeader {...MockProps} languageString="javascript,typescript" />);
+
+    await waitFor(() => {
+      expect(mainStore.getSpecificWorkspaceBounties).toHaveBeenCalledWith(
+        MockProps.workspace_uuid,
+        expect.objectContaining({
+          languages: 'javascript,typescript'
+        })
+      );
+    });
+  });
+
   it('should trigger API call in response to click on status from WorkspaceHeader', async () => {
     const { getByText, getByRole, rerender } = render(<WorkspaceHeader {...MockProps} />);
 
@@ -200,7 +213,7 @@ describe('WorkspaceHeader Component', () => {
           page: 1,
           resetPage: true,
           ...updatedCheckboxIdToSelectedMap,
-          languageString: MockProps.languageString
+          direction: 'desc'
         }
       );
     });

--- a/src/pages/tickets/__tests__/WorkspaceHeader.spec.tsx
+++ b/src/pages/tickets/__tests__/WorkspaceHeader.spec.tsx
@@ -8,6 +8,10 @@ import { mainStore } from '../../../store/main.ts';
 import { uiStore } from '../../../store/ui.ts';
 import * as helpers from '../../../helpers/helpers-extended.ts';
 
+jest.mock('remark-gfm', () => null);
+
+jest.mock('rehype-raw', () => null);
+
 jest.mock('../../../store/main.ts', () => ({
   mainStore: {
     getUserRoles: jest.fn(),

--- a/src/pages/tickets/workspace/WorkspaceTickets.tsx
+++ b/src/pages/tickets/workspace/WorkspaceTickets.tsx
@@ -55,14 +55,15 @@ function WorkspaceBodyComponent() {
   }, [main, ui.meInfo]);
 
   const getTotalBounties = useCallback(
-    async (uuid: any, statusData: any) => {
+    async (uuid: any, statusData: any, languages?: string) => {
       const WorkspaceTotalBounties = await main.getTotalWorkspaceBountyCount(
         uuid,
         statusData?.Open,
         statusData?.Assigned,
         statusData?.Paid,
         statusData?.Pending,
-        statusData?.Failed
+        statusData?.Failed,
+        languages
       );
       setTotalBounties(WorkspaceTotalBounties);
     },
@@ -70,8 +71,8 @@ function WorkspaceBodyComponent() {
   );
 
   useEffect(() => {
-    getTotalBounties(uuid, checkboxIdToSelectedMap);
-  }, [checkboxIdToSelectedMap, getTotalBounties, uuid]);
+    getTotalBounties(uuid, checkboxIdToSelectedMap, languageString);
+  }, [checkboxIdToSelectedMap, getTotalBounties, languageString, uuid]);
 
   const onChangeStatus = (optionId: any) => {
     const newCheckboxIdToSelectedMap = {
@@ -83,7 +84,7 @@ function WorkspaceBodyComponent() {
     // set the store status, to enable the accurate navigation modal call
     main.setWorkspaceBountiesStatus(newCheckboxIdToSelectedMap);
     setCheckboxIdToSelectedMap(newCheckboxIdToSelectedMap);
-    getTotalBounties(uuid, newCheckboxIdToSelectedMap);
+    getTotalBounties(uuid, newCheckboxIdToSelectedMap, languageString);
     // set data to default
     setCurrentItems(queryLimit);
     setPage(1);
@@ -101,6 +102,9 @@ function WorkspaceBodyComponent() {
     setLanguageString(languageString);
 
     main.setBountyLanguages(languageString);
+    getTotalBounties(uuid, checkboxIdToSelectedMap, languageString);
+    setCurrentItems(queryLimit);
+    setPage(1);
   };
 
   const onPanelClick = (activeWorkspace: string, item: any) => {

--- a/src/pages/tickets/workspace/workspaceHeader/index.tsx
+++ b/src/pages/tickets/workspace/workspaceHeader/index.tsx
@@ -124,11 +124,14 @@ export const WorkspaceHeader = ({
   };
 
   const handleSearch = (searchText: string) => {
+    const languageParams = languageString ? { languages: languageString } : {};
+
     if (workspace_uuid) {
       main.getSpecificWorkspaceBounties(workspace_uuid, {
         page: 1,
         resetPage: true,
         ...checkboxIdToSelectedMap,
+        ...languageParams,
         search: searchText
       });
     } else {
@@ -149,12 +152,14 @@ export const WorkspaceHeader = ({
   };
 
   useEffect(() => {
+    const languageParams = languageString ? { languages: languageString } : {};
+
     if (workspace_uuid) {
       main.getSpecificWorkspaceBounties(workspace_uuid, {
         page: 1,
         resetPage: true,
         ...checkboxIdToSelectedMap,
-        languageString,
+        ...languageParams,
         direction: sortDirection
       });
     }

--- a/src/people/widgetViews/WidgetSwitchViewer.tsx
+++ b/src/people/widgetViews/WidgetSwitchViewer.tsx
@@ -230,6 +230,7 @@ function WidgetSwitchViewer(props: any) {
     await main.getPeopleBounties({
       limit: queryLimit,
       page: currentPage,
+      ...(languageString ? { languages: languageString } : {}),
       ...props.checkboxIdToSelectedMap
     });
   };
@@ -246,6 +247,7 @@ function WidgetSwitchViewer(props: any) {
     await main.getSpecificWorkspaceBounties(uuid, {
       limit: queryLimit,
       page: currentPage,
+      ...(languageString ? { languages: languageString } : {}),
       ...props.checkboxIdToSelectedMap
     });
   };

--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -4424,12 +4424,19 @@ export class MainStore {
     assigned: boolean,
     paid: boolean,
     pending: boolean,
-    failed: boolean
+    failed: boolean,
+    languages?: string
   ): Promise<number> {
     try {
-      const count = await api.get(
-        `workspaces/bounties/${uuid}/count?Open=${open}&Assigned=${assigned}&Paid=${paid}&Pending=${pending}&Failed=${failed}`
-      );
+      const query = new URLSearchParams({
+        Open: String(open),
+        Assigned: String(assigned),
+        Paid: String(paid),
+        Pending: String(pending),
+        Failed: String(failed),
+        ...(languages ? { languages } : {})
+      });
+      const count = await api.get(`workspaces/bounties/${uuid}/count?${query.toString()}`);
       return await count;
     } catch (e) {
       console.log('fetch failed getTotalWorkspaceBountyCount: ', e);


### PR DESCRIPTION
## Summary
- send selected workspace skill filters with the API-supported `languages` query key instead of the UI-only `languageString` prop
- preserve the selected skill filter for workspace search, load more, and bounty count requests
- reset workspace pagination when the skill filter changes
- add a regression test covering the `languages` query key

Fixes #586

## Validation
- git diff --check

I did not run the Jest suite locally because this checkout does not have `node_modules` installed.

Bounty/payout note: if accepted for the bounty, payout can be sent to 0xB34D185318b34ec2F9E060F662Cc7feA3180049c.