### PR TITLE
Show submit proof button on mobile for assignees

### DIFF
--- a/src/people/interfaces.ts
+++ b/src/people/interfaces.ts
@@ -369,6 +369,7 @@ export interface CodingViewProps extends WantedSummaryProps {
   isCopied?: boolean;
   payBounty?: ReactNode;
   markUnpaid?: ReactNode;
+  submitProofButton?: ReactNode;
   showPayBounty?: boolean;
   paid: boolean;
   // owner_id: string;

--- a/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/CodingBounty.tsx
@@ -715,6 +715,24 @@ function MobileView(props: CodingBountiesProps) {
     openModal();
   };
 
+  const submitProofButton = isAssignee && (
+    <Button
+      iconSize={14}
+      width={'100%'}
+      height={48}
+      color="withdraw"
+      onClick={() => setIsOpenProofModal(true)}
+      style={{
+        marginBottom: '20px'
+      }}
+      ButtonTextStyle={{
+        fontSize: '15px',
+        fontFamily: 'Barlow'
+      }}
+      text="Submit Proof"
+    />
+  );
+
   useEffect(() => {
     setPaidStatus(paid);
   }, [paid]);
@@ -773,26 +791,10 @@ function MobileView(props: CodingBountiesProps) {
         assigneeValue={assigneeValue}
         peopleList={peopleList}
         handleAssigneeDetails={handleAssigneeDetails}
+        submitProofButton={submitProofButton}
         markPaidOrUnpaid={
           hasAccess && (
             <>
-              {isAssignee && (
-                <Button
-                  iconSize={14}
-                  width={'100%'}
-                  height={48}
-                  color="withdraw"
-                  onClick={() => setIsOpenProofModal(true)}
-                  style={{
-                    marginBottom: '20px'
-                  }}
-                  ButtonTextStyle={{
-                    fontSize: '15px',
-                    fontFamily: 'Barlow'
-                  }}
-                  text="Submit Proof"
-                />
-              )}
               <IconButton
                 width={'100%'}
                 height={48}

--- a/src/people/widgetViews/summaries/wantedSummaries/CodingMobile.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/CodingMobile.tsx
@@ -85,7 +85,8 @@ export default function MobileView(props: CodingViewProps) {
     assigneeHandlerOpen,
     assigneeValue,
     peopleList,
-    handleAssigneeDetails
+    handleAssigneeDetails,
+    submitProofButton
   } = props;
 
   const color = colors['light'];
@@ -448,6 +449,7 @@ export default function MobileView(props: CodingViewProps) {
             />
           </ButtonRow>
 
+          {submitProofButton}
           {hasAccess && isAssigner && markPaidOrUnpaid}
           <LoomViewerRecorder readOnly loomEmbedUrl={loomEmbedUrl} style={{ marginBottom: 20 }} />
 

--- a/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
@@ -191,6 +191,50 @@ describe('MobileView component', () => {
     expect(completionDate).toBeInTheDocument();
   });
 
+  it('shows submit proof on mobile for the assigned hunter', async () => {
+    const originalInnerWidth = window.innerWidth;
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 899
+    });
+
+    uiStore.setMeInfo({
+      ...user,
+      owner_pubkey: 'assigned-hunter-pubkey',
+      owner_alias: 'Assigned Hunter'
+    });
+
+    render(
+      <MobileView
+        {...defaultProps}
+        owner_id="bounty-owner-pubkey"
+        person={
+          {
+            owner_pubkey: 'bounty-owner-pubkey',
+            owner_alias: 'Bounty Owner'
+          } as any
+        }
+        assignee={
+          {
+            owner_pubkey: 'assigned-hunter-pubkey',
+            owner_alias: 'Assigned Hunter'
+          } as any
+        }
+        isAssigned={true}
+      />
+    );
+
+    expect(await screen.findByText('Submit Proof')).toBeInTheDocument();
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: originalInnerWidth
+    });
+  });
+
   it('Test that on clicking on "not assigned", a pop up should appear to invite a developer including "type to search" box, a "skills" box, and a recommendation of 5 hunters.', async () => {
     const props: CodingBountiesProps = {
       ...defaultProps,

--- a/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
+++ b/src/people/widgetViews/summaries/wantedSummaries/__tests__/CodingBounty.spec.tsx
@@ -193,6 +193,16 @@ describe('MobileView component', () => {
 
   it('shows submit proof on mobile for the assigned hunter', async () => {
     const originalInnerWidth = window.innerWidth;
+    const mockGetFeatureFlags = jest.spyOn(mainStore, 'getFeatureFlags').mockResolvedValue({
+      success: true,
+      data: []
+    });
+    const mockGetUserRoles = jest.spyOn(mainStore, 'getUserRoles').mockResolvedValue([]);
+    const mockGetUserWorkspaceByUuid = jest
+      .spyOn(mainStore, 'getUserWorkspaceByUuid')
+      .mockResolvedValue({
+        owner_pubkey: 'bounty-owner-pubkey'
+      } as any);
 
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
@@ -227,12 +237,20 @@ describe('MobileView component', () => {
     );
 
     expect(await screen.findByText('Submit Proof')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockGetFeatureFlags).toHaveBeenCalled();
+      expect(mockGetUserRoles).toHaveBeenCalled();
+      expect(mockGetUserWorkspaceByUuid).toHaveBeenCalled();
+    });
 
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
       writable: true,
       value: originalInnerWidth
     });
+    mockGetFeatureFlags.mockRestore();
+    mockGetUserRoles.mockRestore();
+    mockGetUserWorkspaceByUuid.mockRestore();
   });
 
   it('Test that on clicking on "not assigned", a pop up should appear to invite a developer including "type to search" box, a "skills" box, and a recommendation of 5 hunters.', async () => {


### PR DESCRIPTION
## Summary
- render the mobile Submit Proof action from the assignee condition, matching desktop behavior
- keep owner/manage-bounty payment controls separate from assignee proof submission
- add a regression test for an assigned hunter viewing the bounty on mobile

Fixes #1296

## Validation
- git diff --check

I did not run the Jest suite locally because this checkout does not have `node_modules` installed.

Bounty/payout note: if accepted for the bounty, payout can be sent to 0xB34D185318b34ec2F9E060F662Cc7feA3180049c.