### PR TITLE
Keep mobile profile edit actions visible

### DIFF
--- a/src/people/userInfo/MobileHeader.tsx
+++ b/src/people/userInfo/MobileHeader.tsx
@@ -5,13 +5,18 @@ import React from 'react';
 export const HeaderMobile = ({ goBack, canEdit, logout, onEdit }: PeopleMobileeHeaderProps) => (
   <div
     style={{
-      position: 'absolute',
-      top: 20,
+      position: 'sticky',
+      top: 0,
       left: 0,
       display: 'flex',
       justifyContent: 'space-between',
+      alignItems: 'center',
       width: '100%',
-      padding: '0 20px'
+      minHeight: 64,
+      padding: '0 20px',
+      background: '#ffffff',
+      borderBottom: '1px solid #ebedef',
+      zIndex: 10
     }}
   >
     <IconButton onClick={goBack} icon="arrow_back" />

--- a/src/people/userInfo/styles.ts
+++ b/src/people/userInfo/styles.ts
@@ -62,6 +62,6 @@ export const Img = styled.div<ImageProps>`
   @media (max-width: 768px) {
     width: 100px;
     height: 100px;
-    margin-top: 50px;
+    margin-top: 24px;
   }
 `;


### PR DESCRIPTION
## Summary
- change the mobile profile action header from an unstacked absolute overlay to a sticky top bar
- add z-index, background, border, and vertical alignment so Edit Profile and Sign out remain visible and clickable
- reduce the mobile avatar top spacing now that the header occupies normal layout space

Fixes #1292

## Validation
- git diff --check

I did not run the Jest suite locally because this checkout does not have `node_modules` installed.

Bounty/payout note: if accepted for the bounty, payout can be sent to 0xB34D185318b34ec2F9E060F662Cc7feA3180049c.