### PR TITLE
Fix mobile sidebar header overlap

### DIFF
--- a/src/components/common/SidebarComponent.tsx
+++ b/src/components/common/SidebarComponent.tsx
@@ -32,6 +32,9 @@ import { Toast } from '../../people/widgetViews/workspace/interface.ts';
 import { archiveIcon } from './DeleteConfirmationModal/archiveIcon.tsx';
 
 const color = colors['light'];
+// Mobile PeopleHeader includes the logo row and tabs; keep the fixed sidebar below it.
+const MOBILE_HEADER_OFFSET = '96px';
+const MOBILE_HAMBURGER_OFFSET = '14px';
 
 const IconWrapper = styled.div`
   margin-bottom: 4px;
@@ -53,6 +56,8 @@ const SidebarContainer = styled.div<{ collapsed: boolean }>`
 
   @media (max-width: 768px) {
     width: ${({ collapsed }) => (collapsed ? '60px' : '100%')};
+    top: ${MOBILE_HEADER_OFFSET};
+    height: calc(100vh - ${MOBILE_HEADER_OFFSET});
   }
 
   &::-webkit-scrollbar {
@@ -78,7 +83,7 @@ const HamburgerButton = styled.button<{ topPosition?: string }>`
   z-index: 1000;
 
   @media (max-width: 768px) {
-    margin-top: ${(props) => props.topPosition || '110px'};
+    margin-top: ${(props) => props.topPosition || MOBILE_HAMBURGER_OFFSET};
     transition: left 0.3s ease-in-out;
   }
 `;

--- a/src/components/common/__tests__/SidebarComponent.spec.tsx
+++ b/src/components/common/__tests__/SidebarComponent.spec.tsx
@@ -5,6 +5,10 @@ import { BrowserRouter } from 'react-router-dom';
 import { useStores } from 'store';
 import SidebarComponent from '../SidebarComponent';
 
+jest.mock('remark-gfm', () => null);
+
+jest.mock('rehype-raw', () => null);
+
 jest.mock('store', () => ({
   useStores: jest.fn()
 }));
@@ -44,6 +48,20 @@ describe('SidebarComponent Tooltip Tests', () => {
   });
 
   describe('Navigation Item Tooltips', () => {
+    test('should offset the mobile sidebar below the global header', () => {
+      renderSidebar({ defaultCollapsed: true });
+
+      const injectedStyles = Array.from(document.head.querySelectorAll('style'))
+        .map((style) => style.textContent)
+        .join(' ')
+        .replace(/\s/g, '');
+
+      expect(injectedStyles).toContain('@media(max-width:768px)');
+      expect(injectedStyles).toContain('top:96px;');
+      expect(injectedStyles).toContain('height:calc(100vh-96px);');
+      expect(injectedStyles).toContain('margin-top:14px;');
+    });
+
     test('should show tooltip for activities when collapsed', async () => {
       renderSidebar({ defaultCollapsed: true });
       const activitiesButton = screen.getByLabelText('Activities');


### PR DESCRIPTION
## Summary
- Fixes the mobile workspace sidebar so it starts below the global Sphinx Community header instead of covering the logo/nav area.
- Keeps the desktop sidebar behavior unchanged.
- Adds a regression test that asserts the generated mobile sidebar CSS includes the header offset and adjusted hamburger offset.

Fixes #1360.

## Validation
- `REACT_APP_IS_TEST=true NODE_ENV=test yarn jest src/components/common/__tests__/SidebarComponent.spec.tsx --runInBand --no-cache --coverage=false --testNamePattern="offset the mobile sidebar"`
  - PASS: 1 targeted test passed, 14 skipped.
  - Existing output: ts-jest version warning and a pre-existing async act warning from SidebarComponent feature fetching.
- `yarn eslint src/components/common/SidebarComponent.tsx src/components/common/__tests__/SidebarComponent.spec.tsx --max-warnings 100 --ext .ts --ext .tsx`
  - PASS.
- Local visual check with Chrome at 430x932 against `http://127.0.0.1:3008/workspace/test-uuid/activities` after seeding a throwaway local `meInfo` value:
  - Header logo and tabs remain unobscured.
  - Sidebar begins below the mobile header.
  - Screenshot captured locally at `bounty-ops/sphinx-1360-mobile-sidebar-seeded-after.png`.