### PR TITLE
Persist referral query parameter for profile creation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { uiStore } from 'store/ui';
 import './App.css';
 import { ThemeProvider, createTheme } from '@mui/system';
 import { usePostHog } from 'posthog-js/react';
+import { persistReferredByFromSearch } from 'helpers/referral';
 import { ModeDispatcher } from './config/ModeDispatcher';
 import { Pages } from './pages';
 import { appEnv } from './config/env';
@@ -89,6 +90,8 @@ function App() {
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
+    persistReferredByFromSearch(window.location.search);
+
     const prefillParam = urlParams.get('prefill');
     const action = urlParams.get('action');
 

--- a/src/helpers/__test__/referral.spec.ts
+++ b/src/helpers/__test__/referral.spec.ts
@@ -1,0 +1,74 @@
+import {
+  REFERRED_BY_STORAGE_KEY,
+  appendStoredReferredBy,
+  getStoredReferredBy,
+  persistReferredByFromSearch
+} from '../referral';
+
+const createStorage = (initialValues: Record<string, string> = {}) => {
+  const values = { ...initialValues };
+
+  return {
+    getItem: jest.fn((key: string) => values[key] ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+      values[key] = value;
+    }),
+    removeItem: jest.fn((key: string) => {
+      delete values[key];
+    }),
+    clear: jest.fn(() => {
+      Object.keys(values).forEach((key) => delete values[key]);
+    }),
+    key: jest.fn((index: number) => Object.keys(values)[index] ?? null),
+    get length() {
+      return Object.keys(values).length;
+    }
+  } as unknown as Storage;
+};
+
+describe('referral helpers', () => {
+  it('stores the p query value as referred_by', () => {
+    const storage = createStorage();
+
+    const referredBy = persistReferredByFromSearch('?p=abc-123', storage);
+
+    expect(referredBy).toBe('abc-123');
+    expect(storage.setItem).toHaveBeenCalledWith(REFERRED_BY_STORAGE_KEY, 'abc-123');
+    expect(getStoredReferredBy(storage)).toBe('abc-123');
+  });
+
+  it('does not overwrite an existing referred_by value', () => {
+    const storage = createStorage({ [REFERRED_BY_STORAGE_KEY]: 'first-referrer' });
+
+    const referredBy = persistReferredByFromSearch('?p=second-referrer', storage);
+
+    expect(referredBy).toBe('first-referrer');
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('ignores invalid p query values', () => {
+    const storage = createStorage();
+
+    const referredBy = persistReferredByFromSearch('?p=<script>alert(1)</script>', storage);
+
+    expect(referredBy).toBeNull();
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('appends stored referred_by to new profile payloads', () => {
+    const storage = createStorage({ [REFERRED_BY_STORAGE_KEY]: 'referrer-uuid' });
+
+    expect(appendStoredReferredBy({ owner_alias: 'Ada' }, storage)).toEqual({
+      owner_alias: 'Ada',
+      referred_by: 'referrer-uuid'
+    });
+  });
+
+  it('keeps an explicit referred_by payload value', () => {
+    const storage = createStorage({ [REFERRED_BY_STORAGE_KEY]: 'stored-referrer' });
+
+    expect(appendStoredReferredBy({ referred_by: 'explicit-referrer' }, storage)).toEqual({
+      referred_by: 'explicit-referrer'
+    });
+  });
+});

--- a/src/helpers/referral.ts
+++ b/src/helpers/referral.ts
@@ -1,0 +1,55 @@
+export const REFERRED_BY_STORAGE_KEY = 'referred_by';
+
+const REFERRAL_ID_PATTERN = /^[a-zA-Z0-9-]{1,64}$/;
+
+const getStorage = (storage?: Storage): Storage | undefined => {
+  if (storage) return storage;
+  if (typeof window === 'undefined') return undefined;
+  return window.localStorage;
+};
+
+export const normalizeReferralCode = (value?: string | null): string => {
+  const trimmedValue = value?.trim() ?? '';
+  return REFERRAL_ID_PATTERN.test(trimmedValue) ? trimmedValue : '';
+};
+
+export const getStoredReferredBy = (storage?: Storage): string | null => {
+  const localStorageRef = getStorage(storage);
+  if (!localStorageRef) return null;
+
+  return normalizeReferralCode(localStorageRef.getItem(REFERRED_BY_STORAGE_KEY)) || null;
+};
+
+export const persistReferredByFromSearch = (
+  search: string,
+  storage?: Storage
+): string | null => {
+  const localStorageRef = getStorage(storage);
+  if (!localStorageRef || localStorageRef.getItem(REFERRED_BY_STORAGE_KEY)) {
+    return getStoredReferredBy(localStorageRef);
+  }
+
+  const searchParams = new URLSearchParams(search);
+  const referredBy = normalizeReferralCode(searchParams.get('p'));
+
+  if (!referredBy) return null;
+
+  localStorageRef.setItem(REFERRED_BY_STORAGE_KEY, referredBy);
+  return referredBy;
+};
+
+export const appendStoredReferredBy = <T extends Record<string, any>>(
+  body: T,
+  storage?: Storage
+): T & { referred_by?: string } => {
+  const referredBy = getStoredReferredBy(storage);
+
+  if (!referredBy || body.referred_by) {
+    return body;
+  }
+
+  return {
+    ...body,
+    referred_by: referredBy
+  };
+};

--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -9,6 +9,7 @@ import api from '../api';
 import { getHostIncludingDockerHosts } from '../config/host';
 import { TribesURL } from '../config/host';
 import { convertLocaleToNumber, randomString } from '../helpers';
+import { appendStoredReferredBy } from '../helpers/referral';
 import { getUserAvatarPlaceholder } from './lib';
 import { uiStore } from './ui';
 import {
@@ -1739,9 +1740,7 @@ export class MainStore {
 
     const r = await fetch(`${TribesURL}/person`, {
       method: 'POST',
-      body: JSON.stringify({
-        ...body
-      }),
+      body: JSON.stringify(appendStoredReferredBy(body)),
       mode: 'cors',
       headers: {
         'x-jwt': info.tribe_jwt,


### PR DESCRIPTION
## Summary
- Captures a valid `?p=<uuid>` referral query value into `localStorage.referred_by` on app load.
- Preserves the first stored referrer and ignores later `p` query values once `referred_by` already exists.
- Adds the stored `referred_by` value to new profile `POST /person` payloads via `saveBountyPerson`.
- Ignores invalid referral query values before storage or backend submission.

Fixes #183.

## Validation
- `REACT_APP_IS_TEST=true NODE_ENV=test yarn jest src/helpers/__test__/referral.spec.ts --runInBand --no-cache --coverage=false`
  - PASS: 5 tests passed.
- `yarn eslint src/App.tsx src/store/main.ts src/helpers/referral.ts src/helpers/__test__/referral.spec.ts --max-warnings 100 --ext .ts --ext .tsx`
  - PASS with existing App hook dependency warnings only.
- `git diff --check`
  - PASS.