### PR TITLE
Normalize phase planner ticket data

### DIFF
--- a/src/helpers/__test__/phaseTickets.spec.ts
+++ b/src/helpers/__test__/phaseTickets.spec.ts
@@ -1,0 +1,75 @@
+import { extractPhaseTickets, normalizePhaseTicket } from '../phaseTickets';
+import type { Ticket } from 'store/interface';
+
+const baseTicket: Ticket = {
+  uuid: 'ticket-1',
+  feature_uuid: 'feature-1',
+  phase_uuid: 'phase-1',
+  name: 'Planner ticket',
+  sequence: 1,
+  description: 'Ticket description',
+  status: 'DRAFT',
+  version: 1
+};
+
+describe('phase ticket helpers', () => {
+  describe('extractPhaseTickets', () => {
+    it('returns a raw ticket array', () => {
+      expect(extractPhaseTickets([baseTicket])).toEqual([baseTicket]);
+    });
+
+    it('returns wrapped tickets from tickets or data keys', () => {
+      expect(extractPhaseTickets({ tickets: [baseTicket] })).toEqual([baseTicket]);
+      expect(extractPhaseTickets({ data: [baseTicket] })).toEqual([baseTicket]);
+    });
+
+    it('returns an empty list for missing or unexpected payloads', () => {
+      expect(extractPhaseTickets(undefined)).toEqual([]);
+      expect(extractPhaseTickets({})).toEqual([]);
+    });
+  });
+
+  describe('normalizePhaseTicket', () => {
+    it('normalizes UUID and missing phase fields before storing the ticket', () => {
+      const normalized = normalizePhaseTicket(
+        {
+          ...baseTicket,
+          uuid: '',
+          UUID: 'api-ticket-1',
+          feature_uuid: '',
+          phase_uuid: '',
+          ticket_group: '',
+          sequence: Number.NaN,
+          number: 4
+        },
+        'feature-2',
+        'phase-2',
+        9
+      );
+
+      expect(normalized).toMatchObject({
+        uuid: 'api-ticket-1',
+        feature_uuid: 'feature-2',
+        phase_uuid: 'phase-2',
+        ticket_group: 'api-ticket-1',
+        sequence: 4
+      });
+    });
+
+    it('returns undefined when no usable ticket id is present', () => {
+      expect(
+        normalizePhaseTicket(
+          {
+            ...baseTicket,
+            uuid: '',
+            ticketUUID: '',
+            UUID: ''
+          },
+          'feature-1',
+          'phase-1',
+          1
+        )
+      ).toBeUndefined();
+    });
+  });
+});

--- a/src/helpers/phaseTickets.ts
+++ b/src/helpers/phaseTickets.ts
@@ -1,0 +1,38 @@
+import type { Ticket } from 'store/interface';
+
+type PhaseTicketEnvelope = Ticket[] | { tickets?: Ticket[]; data?: Ticket[] } | undefined;
+type PhaseTicketWithFallbacks = Ticket & { ID?: string; id?: string; number?: number };
+
+export function extractPhaseTickets(payload: PhaseTicketEnvelope): Ticket[] {
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.tickets)) return payload.tickets;
+  if (Array.isArray(payload?.data)) return payload.data;
+  return [];
+}
+
+export function normalizePhaseTicket(
+  ticket: PhaseTicketWithFallbacks,
+  feature_uuid: string,
+  phase_uuid: string,
+  fallbackSequence: number
+): Ticket | undefined {
+  const uuid = ticket.uuid || ticket.UUID || ticket.ticketUUID || ticket.ID || ticket.id;
+  if (!uuid) return undefined;
+
+  const apiSequence = Number(ticket.sequence);
+  const apiNumber = Number(ticket.number);
+  const sequence = Number.isFinite(apiSequence)
+    ? apiSequence
+    : Number.isFinite(apiNumber)
+      ? apiNumber
+      : fallbackSequence;
+
+  return {
+    ...ticket,
+    uuid,
+    feature_uuid: ticket.feature_uuid || feature_uuid,
+    phase_uuid: ticket.phase_uuid || phase_uuid,
+    ticket_group: ticket.ticket_group || uuid,
+    sequence
+  };
+}

--- a/src/people/widgetViews/PhasePlannerView.tsx
+++ b/src/people/widgetViews/PhasePlannerView.tsx
@@ -7,6 +7,7 @@ import MaterialIcon from '@material/react-material-icon';
 import TicketEditor from 'components/common/TicketEditor/TicketEditor';
 import { useStores } from 'store';
 import { userHasRole } from 'helpers';
+import { normalizePhaseTicket } from 'helpers/phaseTickets';
 import { EuiLoadingSpinner } from '@elastic/eui';
 import { Body } from 'pages/tickets/style';
 import {
@@ -433,7 +434,13 @@ const PhasePlannerView: React.FC = observer(() => {
   const getPhaseTickets = useCallback(async () => {
     if (!feature_uuid || !phase_uuid) return;
     const data = await main.getTicketDataByPhase(feature_uuid, phase_uuid);
-    return data;
+    if (!Array.isArray(data)) return data;
+
+    return data
+      .map((ticket: Ticket, index: number) =>
+        normalizePhaseTicket(ticket, feature_uuid, phase_uuid, index + 1)
+      )
+      .filter((ticket: Ticket | undefined): ticket is Ticket => Boolean(ticket));
   }, [feature_uuid, phase_uuid, main]);
 
   const getTotalBounties = useCallback(
@@ -477,9 +484,6 @@ const PhasePlannerView: React.FC = observer(() => {
             phaseTicketStore.clearPhaseTickets(phase_uuid);
 
             for (const ticket of phaseTickets) {
-              if (ticket.UUID) {
-                ticket.uuid = ticket.UUID;
-              }
               phaseTicketStore.addTicket(ticket);
             }
             setPhaseData(phase);

--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -9,6 +9,7 @@ import api from '../api';
 import { getHostIncludingDockerHosts } from '../config/host';
 import { TribesURL } from '../config/host';
 import { convertLocaleToNumber, randomString } from '../helpers';
+import { extractPhaseTickets } from '../helpers/phaseTickets';
 import { getUserAvatarPlaceholder } from './lib';
 import { uiStore } from './ui';
 import {
@@ -3833,9 +3834,13 @@ export class MainStore {
         }
       });
 
-      return r.json();
+      if (typeof r.ok === 'boolean' && !r.ok) {
+        throw new Error(`Failed to fetch phase tickets: ${r.status}`);
+      }
+
+      return extractPhaseTickets(await r.json());
     } catch (e) {
-      console.error('getFeaturePhaseByUUID', e);
+      console.error('getTicketDataByPhase', e);
       return undefined;
     }
   }


### PR DESCRIPTION
Fixes #686.

## Summary
- normalize tickets returned from `getTicketDataByPhase` before they are stored for the phase planner
- support raw arrays plus `{ tickets }` and `{ data }` response envelopes from the phase-ticket endpoint
- preserve phase/feature UUIDs and stable ticket IDs so `TicketEditor` renders API-returned ticket data under the active phase

## Validation
- `corepack yarn jest src/helpers/__test__/phaseTickets.spec.ts --runInBand --no-cache --coverage=false`
- `corepack yarn eslint src/helpers/phaseTickets.ts src/helpers/__test__/phaseTickets.spec.ts src/people/widgetViews/PhasePlannerView.tsx src/store/main.ts --max-warnings 100 --ext .ts --ext .tsx`
- `git diff --check`