### PR TITLE
Preserve tribe search results on scroll

### DIFF
--- a/src/store/__test__/pageListMerger.spec.ts
+++ b/src/store/__test__/pageListMerger.spec.ts
@@ -1,0 +1,32 @@
+import { MainStore } from '../main';
+
+describe('MainStore.doPageListMerger', () => {
+  it('keeps the current list when a later search page has no results', () => {
+    const store = new MainStore();
+    const setPage = jest.fn();
+    const currentList = [{ uuid: 'tribe-1' }, { uuid: 'tribe-2' }];
+
+    const result = store.doPageListMerger(currentList, [], setPage, {
+      search: 'tribe',
+      page: 2
+    });
+
+    expect(result).toEqual(currentList);
+    expect(setPage).not.toHaveBeenCalled();
+  });
+
+  it('clears the current list when a reset search has no results', () => {
+    const store = new MainStore();
+    const setPage = jest.fn();
+    const currentList = [{ uuid: 'tribe-1' }];
+
+    const result = store.doPageListMerger(currentList, [], setPage, {
+      search: 'missing',
+      page: 1,
+      resetPage: true
+    });
+
+    expect(result).toEqual([]);
+    expect(setPage).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -1448,7 +1448,7 @@ export class MainStore {
     type?: string
   ) {
     if (!newList || !newList.length) {
-      if (queryParams.search) {
+      if (queryParams?.search && queryParams?.resetPage) {
         // if search and no results, return nothing
         return [];
       } else {


### PR DESCRIPTION
Fixes #584.

## Summary
- prevent later empty search pages from clearing already-rendered tribe search results
- keep reset-search behavior intact so a fresh search with no matches still shows an empty state
- add focused regression coverage for both list-merger paths

## Validation
- `corepack yarn jest src/store/__test__/pageListMerger.spec.ts --runInBand --no-cache --coverage=false`
- `corepack yarn eslint src/store/main.ts src/store/__test__/pageListMerger.spec.ts --max-warnings 100 --ext .ts --ext .tsx`
- `git diff --check`