### PR TITLE
test(profile): cover bounties tab

### DIFF
--- a/src/components/common/SidebarComponent.tsx
+++ b/src/components/common/SidebarComponent.tsx
@@ -32,6 +32,10 @@ import { Toast } from '../../people/widgetViews/workspace/interface.ts';
 import { archiveIcon } from './DeleteConfirmationModal/archiveIcon.tsx';
 
 const color = colors['light'];
+const MOBILE_SIDEBAR_BREAKPOINT = 768;
+
+const isMobileSidebar = () =>
+  typeof window !== 'undefined' && window.innerWidth <= MOBILE_SIDEBAR_BREAKPOINT;
 
 const IconWrapper = styled.div`
   margin-bottom: 4px;
@@ -39,7 +43,9 @@ const IconWrapper = styled.div`
 
 const SidebarContainer = styled.div<{ collapsed: boolean }>`
   width: ${({ collapsed }) => (collapsed ? '60px' : '250px')};
-  transition: width 0.3s ease-in-out;
+  transition:
+    width 0.3s ease-in-out,
+    transform 0.3s ease-in-out;
   overflow: hidden;
   position: fixed;
   height: 100vh;
@@ -52,7 +58,8 @@ const SidebarContainer = styled.div<{ collapsed: boolean }>`
   cursor: ${({ collapsed }) => (collapsed ? 'pointer' : 'default')};
 
   @media (max-width: 768px) {
-    width: ${({ collapsed }) => (collapsed ? '60px' : '100%')};
+    width: ${({ collapsed }) => (collapsed ? '56px' : 'min(320px, 86vw)')};
+    height: 100dvh;
   }
 
   &::-webkit-scrollbar {
@@ -69,12 +76,36 @@ const SidebarContainer = styled.div<{ collapsed: boolean }>`
   }
 `;
 
+const SidebarBackdrop = styled.div`
+  display: none;
+
+  @media (max-width: 768px) {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.35);
+    z-index: 999;
+  }
+`;
+
+const SidebarBody = styled.div<{ collapsed: boolean }>`
+  @media (max-width: 768px) {
+    display: ${({ collapsed }) => (collapsed ? 'none' : 'block')};
+  }
+`;
+
 const HamburgerButton = styled.button<{ topPosition?: string }>`
   background: none;
   border: none;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+  min-height: 48px;
   margin-top: ${(props) => props.topPosition || '80px'};
-  margin-left: 10px;
+  margin-left: 6px;
+  padding: 0;
   z-index: 1000;
 
   @media (max-width: 768px) {
@@ -86,6 +117,7 @@ const HamburgerButton = styled.button<{ topPosition?: string }>`
 const NavItem = styled.div<{ collapsed: boolean; active?: boolean }>`
   display: flex;
   align-items: center;
+  min-height: 48px;
   padding: 15px;
   cursor: pointer;
   background-color: ${(props) => (props.active ? '#e0e0e0' : 'transparent')};
@@ -107,6 +139,7 @@ const FeatureHeader = styled.div`
   display: flex;
   align-items: center;
   cursor: pointer;
+  min-height: 48px;
   padding-left: 15px;
   justify-content: space-between;
   &:hover {
@@ -140,6 +173,7 @@ const WorkspaceHeader = styled.div`
   display: flex;
   align-items: center;
   cursor: pointer;
+  min-height: 48px;
   padding-left: 15px;
   justify-content: space-between;
   &:hover {
@@ -202,6 +236,7 @@ const DropdownMenu = styled.div`
 `;
 
 const DropdownItem = styled.div`
+  min-height: 48px;
   padding: 8px 16px;
   display: flex;
   align-items: center;
@@ -330,7 +365,7 @@ export default function SidebarComponent({
   const { ui, main, chat } = useStores();
   const [activeItem, setActiveItem] = useState<'activities' | 'settings' | 'feature' | null>(null);
   const [features, setFeatures] = useState<Feature[]>([]);
-  const [collapsed, setCollapsed] = useState(defaultCollapsed);
+  const [collapsed, setCollapsed] = useState(defaultCollapsed || isMobileSidebar());
   const history = useHistory();
   const [isFeaturesExpanded, setIsFeaturesExpanded] = useState(true);
   const [isWorkspaceExpanded, setIsWorkspaceExpanded] = useState(false);
@@ -352,6 +387,34 @@ export default function SidebarComponent({
   const [tooltipTop, setTooltipTop] = useState(0);
 
   const user_pubkey = ui.meInfo?.owner_pubkey;
+
+  const handleCollapse = useCallback((nextCollapsed: boolean) => {
+    setCollapsed(nextCollapsed);
+    const event = new CustomEvent('sidebarCollapse', {
+      detail: { collapsed: nextCollapsed }
+    });
+    window.dispatchEvent(event);
+  }, []);
+
+  const closeSidebarOnMobile = useCallback(() => {
+    if (isMobileSidebar()) {
+      handleCollapse(true);
+    }
+  }, [handleCollapse]);
+
+  useEffect(() => {
+    const collapseWhenMobile = () => {
+      if (isMobileSidebar()) {
+        handleCollapse(true);
+      }
+    };
+
+    collapseWhenMobile();
+    window.addEventListener('resize', collapseWhenMobile);
+    return () => {
+      window.removeEventListener('resize', collapseWhenMobile);
+    };
+  }, [handleCollapse]);
 
   const getUserWorkspaces = useCallback(async () => {
     setIsLoading(true);
@@ -393,6 +456,7 @@ export default function SidebarComponent({
     } else if (item === 'settings') {
       history.push(`/workspace/${uuid}`);
     }
+    closeSidebarOnMobile();
   };
 
   const handleReorderFeatures = async (feat: Feature, priority: number) => {
@@ -450,16 +514,9 @@ export default function SidebarComponent({
   };
 
   const handleWorkspaceClick = (uuid: string) => {
+    closeSidebarOnMobile();
     window.location.href = `/workspace/${uuid}/activities`;
     setShowDropdown(false);
-  };
-
-  const handleCollapse = (collapsed: boolean) => {
-    setCollapsed(collapsed);
-    const event = new CustomEvent('sidebarCollapse', {
-      detail: { collapsed }
-    });
-    window.dispatchEvent(event);
   };
 
   const toggleFeatureModal = () => {
@@ -593,6 +650,7 @@ export default function SidebarComponent({
       const newChat = await chat.createChat(uuid as string, 'New Chat');
       if (newChat && newChat.id) {
         history.push(`/workspace/${uuid}/hivechat/${newChat.id}`);
+        closeSidebarOnMobile();
       } else {
         ui.setToasts([
           {
@@ -615,14 +673,17 @@ export default function SidebarComponent({
 
   const handleFeatureBacklogClick = () => {
     history.push(`/workspace/${uuid}/feature_backlog`);
+    closeSidebarOnMobile();
   };
 
   const handleKanbanClick = () => {
     history.push(`/workspace/${uuid}/planner`);
+    closeSidebarOnMobile();
   };
 
   const handleCodeGraphClick = () => {
     history.push(`/workspace/${uuid}/codegraph`);
+    closeSidebarOnMobile();
   };
 
   const hasNextPage = chatOffset + CHATS_PER_PAGE < totalChats;
@@ -651,481 +712,536 @@ export default function SidebarComponent({
   };
 
   return (
-    <SidebarContainer
-      collapsed={collapsed}
-      onClick={(e) => {
-        e.stopPropagation();
-        if (collapsed) {
-          handleCollapse(false);
-        }
-      }}
-    >
-      <HamburgerButton
-        onClick={() => handleCollapse(!collapsed)}
-        topPosition={hamburgerTopPosition}
-      >
-        <MaterialIcon icon="menu" style={{ fontSize: 28 }} />
-      </HamburgerButton>
-
-      <WorkspaceTitle collapsed={collapsed}>
-        {main.workspaces
-          .filter((workspace: Workspace) => workspace.uuid === uuid)
-          .map((workspace: Workspace) => (
-            <React.Fragment key={workspace.id}>
-              <WorkspaceImage
-                src={workspace.img || avatarIcon}
-                alt={workspace.name}
-                collapsed={collapsed}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (collapsed) toggleDropdown(e);
-                }}
-                onMouseEnter={(e) => handleMouseEnter(e, `workspace-${workspace.uuid}`)}
-                onMouseLeave={() => setHoveredItem(null)}
-              />
-              {!collapsed && (
-                <>
-                  <div
-                    onMouseEnter={(e) => handleMouseEnter(e, `workspace-budget-${workspace.uuid}`)}
-                    onMouseLeave={() => setHoveredItem(null)}
-                  >
-                    <WorkspaceBudget org={workspace} user_pubkey={user_pubkey ?? ''} />
-                  </div>
-                  <WorkspaceDropdown
-                    collapsed={collapsed}
-                    onClick={toggleDropdown}
-                    onMouseEnter={(e) => handleMouseEnter(e, 'workspace-dropdown')}
-                    onMouseLeave={() => setHoveredItem(null)}
-                  >
-                    <MaterialIcon icon="arrow_drop_down" style={{ fontSize: 24 }} />
-                    {showDropdown && (
-                      <DropdownMenu>
-                        {main.workspaces
-                          .filter((w) => w.uuid !== uuid)
-                          .map((workspace) => (
-                            <DropdownItem
-                              key={workspace.uuid}
-                              onClick={() => handleWorkspaceClick(workspace.uuid)}
-                              onMouseEnter={(e) =>
-                                handleMouseEnter(e, `workspace-${workspace.uuid}`)
-                              }
-                              onMouseLeave={() => setHoveredItem(null)}
-                            >
-                              <DropdownWorkspaceImage
-                                src={workspace.img || avatarIcon}
-                                alt={workspace.name}
-                              />
-                              <div onClick={(e) => e.stopPropagation()}>
-                                <WorkspaceBudget org={workspace} user_pubkey={user_pubkey ?? ''} />
-                              </div>
-                            </DropdownItem>
-                          ))}
-                      </DropdownMenu>
-                    )}
-                  </WorkspaceDropdown>
-                </>
-              )}
-              {(collapsed || hoveredItem === `workspace-${workspace.uuid}`) && (
-                <Tooltip
-                  visible={hoveredItem === `workspace-${workspace.uuid}`}
-                  top={tooltipTop}
-                  collapsed={collapsed}
-                >
-                  {workspace.name}
-                </Tooltip>
-              )}
-              {hoveredItem === `workspace-budget-${workspace.uuid}` && (
-                <Tooltip visible={true} top={tooltipTop} collapsed={collapsed}>
-                  {workspace.name}
-                </Tooltip>
-              )}
-              {hoveredItem === 'workspace-dropdown' && (
-                <Tooltip visible={true} top={tooltipTop} collapsed={collapsed}>
-                  Switch Workspace
-                </Tooltip>
-              )}
-            </React.Fragment>
-          ))}
-      </WorkspaceTitle>
-
-      <NavItem
-        active={activeItem === 'activities'}
-        onClick={() => handleItemClick('activities')}
-        collapsed={collapsed}
-        onMouseEnter={(e) => handleMouseEnter(e, 'activities')}
-        onMouseLeave={() => setHoveredItem(null)}
-        aria-label="Activities"
-      >
-        <MaterialIcon icon="home" />
-        <span>Activities</span>
-        {(collapsed || hoveredItem === 'activities') && (
-          <Tooltip visible={hoveredItem === 'activities'} top={tooltipTop} collapsed={collapsed}>
-            Activities
-          </Tooltip>
-        )}
-      </NavItem>
-
-      <NavItem
-        active={window.location.pathname.includes('kanban')}
-        onClick={handleKanbanClick}
-        collapsed={collapsed}
-        onMouseEnter={(e) => handleMouseEnter(e, 'kanban')}
-        onMouseLeave={() => setHoveredItem(null)}
-        aria-label="Kanban"
-      >
-        <img
-          src="/static/kanban.png"
-          alt="kanban"
-          style={{
-            width: '22px',
-            height: '25px',
-            marginBottom: '4px',
-            marginLeft: '2px'
-          }}
-        />
-        <span>Kanban</span>
-        {(collapsed || hoveredItem === 'kanban') && (
-          <Tooltip visible={hoveredItem === 'kanban'} top={tooltipTop} collapsed={collapsed}>
-            Kanban
-          </Tooltip>
-        )}
-      </NavItem>
-
-      <NavItem
-        active={window.location.pathname.includes('feature_backlog')}
-        onClick={handleFeatureBacklogClick}
-        collapsed={collapsed}
-        onMouseEnter={(e) => handleMouseEnter(e, 'backlog')}
-        onMouseLeave={() => setHoveredItem(null)}
-        aria-label="Feature Backlog"
-      >
-        <img
-          src="/static/backlog.png"
-          alt="feature_backlog"
-          style={{
-            width: '22px',
-            height: '22px',
-            marginBottom: '4px',
-            marginLeft: '2px'
-          }}
-        />
-        <span>Backlog</span>
-        {(collapsed || hoveredItem === 'backlog') && (
-          <Tooltip visible={hoveredItem === 'backlog'} top={tooltipTop} collapsed={collapsed}>
-            Feature Backlog
-          </Tooltip>
-        )}
-      </NavItem>
-
-      <NavItem
-        active={window.location.pathname.includes('/codegraph')}
-        onClick={handleCodeGraphClick}
-        collapsed={collapsed}
-        onMouseEnter={(e) => handleMouseEnter(e, 'codegraph')}
-        onMouseLeave={() => setHoveredItem(null)}
-        aria-label="Code Graph"
-      >
-        <MaterialIcon icon="code" />
-        <span>Code Graph</span>
-        {(collapsed || hoveredItem === 'codegraph') && (
-          <Tooltip visible={hoveredItem === 'codegraph'} top={tooltipTop} collapsed={collapsed}>
-            Code Graph
-          </Tooltip>
-        )}
-      </NavItem>
-
-      <NavItem
-        active={activeItem === 'settings'}
-        onClick={() => handleItemClick('settings')}
-        collapsed={collapsed}
-        onMouseEnter={(e) => handleMouseEnter(e, 'settings')}
-        onMouseLeave={() => setHoveredItem(null)}
-        aria-label="Settings"
-      >
-        <MaterialIcon icon="settings" />
-        <span>Settings</span>
-        {(collapsed || hoveredItem === 'settings') && (
-          <Tooltip visible={hoveredItem === 'settings'} top={tooltipTop} collapsed={collapsed}>
-            Settings
-          </Tooltip>
-        )}
-      </NavItem>
-
+    <>
       {!collapsed && (
-        <FeaturesSection>
-          <FeatureHeader
-            onClick={toggleChats}
-            onMouseEnter={(e) => handleMouseEnter(e, 'chats')}
-            onMouseLeave={() => setHoveredItem(null)}
-          >
-            <h6>Chats</h6>
-            <div style={{ display: 'flex', alignItems: 'center' }}>
-              <MaterialIcon
-                data-testid="add-chat-button"
-                icon="add"
-                style={{ marginRight: '10px', cursor: 'pointer' }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleNewChat();
-                }}
-                onMouseEnter={(e) => {
-                  e.stopPropagation();
-                  setHoveredItem('new-chat');
-                }}
-                onMouseLeave={() => setHoveredItem(null)}
-              />
-              {hoveredItem === 'new-chat' && (
-                <Tooltip visible={true} top={tooltipTop} collapsed={collapsed}>
-                  New Chat
-                </Tooltip>
-              )}
-              <MaterialIcon
-                icon={isChatsExpanded ? 'arrow_drop_down' : 'arrow_right'}
-                style={{ marginRight: '5px' }}
-              />
-            </div>
-            {hoveredItem === 'chats' && (
-              <Tooltip visible={hoveredItem === 'chats'} top={tooltipTop} collapsed={collapsed}>
-                Chats
-              </Tooltip>
-            )}
-          </FeatureHeader>
-          {isChatsExpanded && (
-            <div data-testid="chat-list">
-              {isLoadingChats ? (
-                <LoadingContainer data-testid="chat-loading-spinner">
-                  <EuiLoadingSpinner size="m" />
-                </LoadingContainer>
-              ) : (
-                <>
-                  {paginatedChats.map((chat) => (
-                    <NavItem
-                      data-testid={`chat-item-${chat.id}`}
-                      key={chat.id}
-                      onClick={() => history.push(`/workspace/${uuid}/hivechat/${chat.id}`)}
-                      collapsed={collapsed}
-                      active={window.location.pathname.includes(`/hivechat/${chat.id}`)}
-                    >
-                      <MissionRowFlex>
-                        {!collapsed && (
-                          <FeatureData>
-                            <ChatItemContainer>
-                              <ChatItemContent>
-                                <ChatTitle>{chat.title || 'Untitled Chat'}</ChatTitle>
-                                <ChatTimestamp data-testid={`chat-timestamp-${chat.id}`}>
-                                  {chat.updatedAt || chat.createdAt
-                                    ? new Date(chat.updatedAt || chat.createdAt).toLocaleString()
-                                    : 'No date'}
-                                </ChatTimestamp>
-                              </ChatItemContent>
-                              <MaterialIcon
-                                data-testid="chat-options-button"
-                                icon="more_horiz"
-                                onClick={(e) => toggleChatMenu(chat.id, e)}
-                                style={{ cursor: 'pointer' }}
-                              />
-                            </ChatItemContainer>
-                            {visibleChatMenu[chat.id] && (
-                              <EditPopover>
-                                <EditPopoverTail />
-                                <EditPopoverContent onClick={(e) => confirmArchiveChat(chat.id, e)}>
-                                  <EditPopoverText>Archive</EditPopoverText>
-                                </EditPopoverContent>
-                              </EditPopover>
-                            )}
-                          </FeatureData>
-                        )}
-                      </MissionRowFlex>
-                    </NavItem>
-                  ))}
-                  {!collapsed && paginatedChats.length > 0 && (
-                    <PaginationContainer>
-                      <div
-                        style={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'flex-end'
-                        }}
-                      >
-                        {hasPreviousPage && (
-                          <PaginationButton
-                            icon="chevron_left"
-                            onClick={handlePreviousPage}
-                            data-testid="previous-page-button"
-                          />
-                        )}
-                      </div>
-                      <ViewMoreLink
-                        onClick={() => history.push(`/workspace/${uuid}/hivechat/history`)}
-                        data-testid="view-more-link"
-                      >
-                        View More
-                      </ViewMoreLink>
-                      <div
-                        style={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'flex-start'
-                        }}
-                      >
-                        {hasNextPage && (
-                          <PaginationButton
-                            icon="chevron_right"
-                            onClick={handleNextPage}
-                            data-testid="next-page-button"
-                          />
-                        )}
-                      </div>
-                    </PaginationContainer>
-                  )}
-                </>
-              )}
-            </div>
-          )}
-        </FeaturesSection>
+        <SidebarBackdrop
+          aria-label="Close sidebar"
+          data-testid="sidebar-mobile-backdrop"
+          onClick={() => handleCollapse(true)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ' || e.key === 'Escape') {
+              handleCollapse(true);
+            }
+          }}
+          role="button"
+          tabIndex={0}
+        />
       )}
-
-      {!collapsed && (
-        <FeaturesSection>
-          <FeatureHeader
-            onClick={toggleFeatures}
-            onMouseEnter={(e) => handleMouseEnter(e, 'features')}
-            onMouseLeave={() => setHoveredItem(null)}
-          >
-            <h6>Features</h6>
-            <div style={{ display: 'flex', alignItems: 'center' }}>
-              <MaterialIcon
-                icon="add"
-                data-testid="new-feature-btn"
-                style={{ marginRight: '10px', cursor: 'pointer' }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleAddFeature();
-                }}
-                onMouseEnter={(e) => {
-                  e.stopPropagation();
-                  handleMouseEnter(e, 'new-feature');
-                }}
-                onMouseLeave={() => setHoveredItem(null)}
-              />
-              <MaterialIcon
-                icon={isFeaturesExpanded ? 'arrow_drop_down' : 'arrow_right'}
-                style={{ marginRight: '5px' }}
-              />
-            </div>
-            {hoveredItem === 'features' && (
-              <Tooltip visible={hoveredItem === 'features'} top={tooltipTop} collapsed={collapsed}>
-                Features
-              </Tooltip>
-            )}
-            {hoveredItem === 'new-feature' && (
-              <Tooltip visible={true} top={tooltipTop} collapsed={collapsed}>
-                New Feature
-              </Tooltip>
-            )}
-          </FeatureHeader>
-          {isFeaturesExpanded && (
-            <div>
-              <EuiDragDropContext onDragEnd={onDragEnd}>
-                <EuiDroppable droppableId="features_droppable_area" spacing="m">
-                  {features &&
-                    features.map((feat: Feature, i: number) => (
-                      <EuiDraggable
-                        spacing="m"
-                        key={feat.id}
-                        index={i}
-                        draggableId={feat.uuid}
-                        customDragHandle
-                        hasInteractiveChildren
-                      >
-                        {(provided: any) => (
-                          <NavItem
-                            onClick={() => {
-                              setActiveItem('feature');
-                              history.push(`/workspace/${uuid}/feature/${feat.uuid}`);
-                            }}
-                            key={feat.id}
-                            collapsed={collapsed}
-                            active={
-                              activeItem === 'feature' &&
-                              window.location.pathname.includes(feat.uuid)
-                            }
-                            onMouseEnter={(e) => handleMouseEnter(e, `feature-${feat.uuid}`)}
-                            onMouseLeave={() => setHoveredItem(null)}
-                          >
-                            <MissionRowFlex>
-                              <MaterialIcon
-                                icon="menu"
-                                color="transparent"
-                                className="drag-handle"
-                                paddingSize="s"
-                                {...provided.dragHandleProps}
-                                data-testid={`drag-handle-${feat.priority}`}
-                                aria-label="Drag Handle"
-                                style={{ fontSize: 20, marginBottom: '6px' }}
-                              />
-                              {!collapsed && (
-                                <FeatureData>
-                                  <h6 style={{ marginLeft: '1rem' }}>{feat.name}</h6>
-                                </FeatureData>
-                              )}
-                            </MissionRowFlex>
-                            {(collapsed || hoveredItem === `feature-${feat.uuid}`) && (
-                              <Tooltip
-                                visible={hoveredItem === `feature-${feat.uuid}`}
-                                top={tooltipTop}
-                                collapsed={collapsed}
-                              >
-                                {feat.name}
-                              </Tooltip>
-                            )}
-                          </NavItem>
-                        )}
-                      </EuiDraggable>
-                    ))}
-                </EuiDroppable>
-              </EuiDragDropContext>
-            </div>
-          )}
-        </FeaturesSection>
-      )}
-
-      {featureModal && (
-        <Modal
-          visible={featureModal}
-          style={{
-            height: '100%',
-            flexDirection: 'column'
+      <SidebarContainer
+        aria-label="Workspace sidebar"
+        collapsed={collapsed}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (collapsed) {
+            handleCollapse(false);
+          }
+        }}
+        role="navigation"
+      >
+        <HamburgerButton
+          aria-controls="workspace-sidebar-content"
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? 'Open sidebar' : 'Collapse sidebar'}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleCollapse(!collapsed);
           }}
-          envStyle={{
-            marginTop: 0,
-            background: color.pureWhite,
-            zIndex: 20,
-            maxHeight: '100%',
-            borderRadius: '10px',
-            minWidth: '25%',
-            minHeight: '20%'
-          }}
-          overlayClick={toggleFeatureModal}
-          bigCloseImage={toggleFeatureModal}
-          bigCloseImageStyle={{
-            top: '-18px',
-            right: '-18px',
-            background: '#000',
-            borderRadius: '50%'
-          }}
+          topPosition={hamburgerTopPosition}
         >
-          <AddFeature
-            closeHandler={toggleFeatureModal}
-            getFeatures={() => {
-              fetchFeatures();
-              toggleFeatureModal();
-            }}
-            workspace_uuid={uuid}
-            priority={features.length}
-          />
-        </Modal>
-      )}
-    </SidebarContainer>
+          <MaterialIcon icon="menu" style={{ fontSize: 28 }} />
+        </HamburgerButton>
+
+        <SidebarBody
+          aria-hidden={collapsed && isMobileSidebar()}
+          collapsed={collapsed}
+          id="workspace-sidebar-content"
+        >
+          <WorkspaceTitle collapsed={collapsed}>
+            {main.workspaces
+              .filter((workspace: Workspace) => workspace.uuid === uuid)
+              .map((workspace: Workspace) => (
+                <React.Fragment key={workspace.id}>
+                  <WorkspaceImage
+                    src={workspace.img || avatarIcon}
+                    alt={workspace.name}
+                    collapsed={collapsed}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (collapsed) toggleDropdown(e);
+                    }}
+                    onMouseEnter={(e) => handleMouseEnter(e, `workspace-${workspace.uuid}`)}
+                    onMouseLeave={() => setHoveredItem(null)}
+                  />
+                  {!collapsed && (
+                    <>
+                      <div
+                        onMouseEnter={(e) =>
+                          handleMouseEnter(e, `workspace-budget-${workspace.uuid}`)
+                        }
+                        onMouseLeave={() => setHoveredItem(null)}
+                      >
+                        <WorkspaceBudget org={workspace} user_pubkey={user_pubkey ?? ''} />
+                      </div>
+                      <WorkspaceDropdown
+                        collapsed={collapsed}
+                        data-testid="workspace-dropdown"
+                        onClick={toggleDropdown}
+                        onMouseEnter={(e) => handleMouseEnter(e, 'workspace-dropdown')}
+                        onMouseLeave={() => setHoveredItem(null)}
+                      >
+                        <MaterialIcon icon="arrow_drop_down" style={{ fontSize: 24 }} />
+                        {showDropdown && (
+                          <DropdownMenu>
+                            {main.workspaces
+                              .filter((w) => w.uuid !== uuid)
+                              .map((workspace) => (
+                                <DropdownItem
+                                  key={workspace.uuid}
+                                  onClick={() => handleWorkspaceClick(workspace.uuid)}
+                                  onMouseEnter={(e) =>
+                                    handleMouseEnter(e, `workspace-${workspace.uuid}`)
+                                  }
+                                  onMouseLeave={() => setHoveredItem(null)}
+                                >
+                                  <DropdownWorkspaceImage
+                                    src={workspace.img || avatarIcon}
+                                    alt={workspace.name}
+                                  />
+                                  <div onClick={(e) => e.stopPropagation()}>
+                                    <WorkspaceBudget
+                                      org={workspace}
+                                      user_pubkey={user_pubkey ?? ''}
+                                    />
+                                  </div>
+                                </DropdownItem>
+                              ))}
+                          </DropdownMenu>
+                        )}
+                      </WorkspaceDropdown>
+                    </>
+                  )}
+                  {(collapsed || hoveredItem === `workspace-${workspace.uuid}`) && (
+                    <Tooltip
+                      visible={hoveredItem === `workspace-${workspace.uuid}`}
+                      top={tooltipTop}
+                      collapsed={collapsed}
+                    >
+                      {workspace.name}
+                    </Tooltip>
+                  )}
+                  {hoveredItem === `workspace-budget-${workspace.uuid}` && (
+                    <Tooltip visible={true} top={tooltipTop} collapsed={collapsed}>
+                      {workspace.name}
+                    </Tooltip>
+                  )}
+                  {hoveredItem === 'workspace-dropdown' && (
+                    <Tooltip visible={true} top={tooltipTop} collapsed={collapsed}>
+                      Switch Workspace
+                    </Tooltip>
+                  )}
+                </React.Fragment>
+              ))}
+          </WorkspaceTitle>
+
+          <NavItem
+            active={activeItem === 'activities'}
+            onClick={() => handleItemClick('activities')}
+            collapsed={collapsed}
+            onMouseEnter={(e) => handleMouseEnter(e, 'activities')}
+            onMouseLeave={() => setHoveredItem(null)}
+            aria-label="Activities"
+          >
+            <MaterialIcon icon="home" />
+            <span>Activities</span>
+            {(collapsed || hoveredItem === 'activities') && (
+              <Tooltip
+                visible={hoveredItem === 'activities'}
+                top={tooltipTop}
+                collapsed={collapsed}
+              >
+                Activities
+              </Tooltip>
+            )}
+          </NavItem>
+
+          <NavItem
+            active={window.location.pathname.includes('kanban')}
+            onClick={handleKanbanClick}
+            collapsed={collapsed}
+            onMouseEnter={(e) => handleMouseEnter(e, 'kanban')}
+            onMouseLeave={() => setHoveredItem(null)}
+            aria-label="Kanban"
+          >
+            <img
+              src="/static/kanban.png"
+              alt="kanban"
+              style={{
+                width: '22px',
+                height: '25px',
+                marginBottom: '4px',
+                marginLeft: '2px'
+              }}
+            />
+            <span>Kanban</span>
+            {(collapsed || hoveredItem === 'kanban') && (
+              <Tooltip visible={hoveredItem === 'kanban'} top={tooltipTop} collapsed={collapsed}>
+                Kanban
+              </Tooltip>
+            )}
+          </NavItem>
+
+          <NavItem
+            active={window.location.pathname.includes('feature_backlog')}
+            onClick={handleFeatureBacklogClick}
+            collapsed={collapsed}
+            onMouseEnter={(e) => handleMouseEnter(e, 'backlog')}
+            onMouseLeave={() => setHoveredItem(null)}
+            aria-label="Feature Backlog"
+          >
+            <img
+              src="/static/backlog.png"
+              alt="feature_backlog"
+              style={{
+                width: '22px',
+                height: '22px',
+                marginBottom: '4px',
+                marginLeft: '2px'
+              }}
+            />
+            <span>Backlog</span>
+            {(collapsed || hoveredItem === 'backlog') && (
+              <Tooltip visible={hoveredItem === 'backlog'} top={tooltipTop} collapsed={collapsed}>
+                Feature Backlog
+              </Tooltip>
+            )}
+          </NavItem>
+
+          <NavItem
+            active={window.location.pathname.includes('/codegraph')}
+            onClick={handleCodeGraphClick}
+            collapsed={collapsed}
+            onMouseEnter={(e) => handleMouseEnter(e, 'codegraph')}
+            onMouseLeave={() => setHoveredItem(null)}
+            aria-label="Code Graph"
+          >
+            <MaterialIcon icon="code" />
+            <span>Code Graph</span>
+            {(collapsed || hoveredItem === 'codegraph') && (
+              <Tooltip visible={hoveredItem === 'codegraph'} top={tooltipTop} collapsed={collapsed}>
+                Code Graph
+              </Tooltip>
+            )}
+          </NavItem>
+
+          <NavItem
+            active={activeItem === 'settings'}
+            onClick={() => handleItemClick('settings')}
+            collapsed={collapsed}
+            onMouseEnter={(e) => handleMouseEnter(e, 'settings')}
+            onMouseLeave={() => setHoveredItem(null)}
+            aria-label="Settings"
+          >
+            <MaterialIcon icon="settings" />
+            <span>Settings</span>
+            {(collapsed || hoveredItem === 'settings') && (
+              <Tooltip visible={hoveredItem === 'settings'} top={tooltipTop} collapsed={collapsed}>
+                Settings
+              </Tooltip>
+            )}
+          </NavItem>
+
+          {!collapsed && (
+            <FeaturesSection>
+              <FeatureHeader
+                onClick={toggleChats}
+                onMouseEnter={(e) => handleMouseEnter(e, 'chats')}
+                onMouseLeave={() => setHoveredItem(null)}
+              >
+                <h6>Chats</h6>
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                  <MaterialIcon
+                    data-testid="add-chat-button"
+                    icon="add"
+                    style={{ marginRight: '10px', cursor: 'pointer' }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleNewChat();
+                    }}
+                    onMouseEnter={(e) => {
+                      e.stopPropagation();
+                      setHoveredItem('new-chat');
+                    }}
+                    onMouseLeave={() => setHoveredItem(null)}
+                  />
+                  {hoveredItem === 'new-chat' && (
+                    <Tooltip visible={true} top={tooltipTop} collapsed={collapsed}>
+                      New Chat
+                    </Tooltip>
+                  )}
+                  <MaterialIcon
+                    icon={isChatsExpanded ? 'arrow_drop_down' : 'arrow_right'}
+                    style={{ marginRight: '5px' }}
+                  />
+                </div>
+                {hoveredItem === 'chats' && (
+                  <Tooltip visible={hoveredItem === 'chats'} top={tooltipTop} collapsed={collapsed}>
+                    Chats
+                  </Tooltip>
+                )}
+              </FeatureHeader>
+              {isChatsExpanded && (
+                <div data-testid="chat-list">
+                  {isLoadingChats ? (
+                    <LoadingContainer data-testid="chat-loading-spinner">
+                      <EuiLoadingSpinner size="m" />
+                    </LoadingContainer>
+                  ) : (
+                    <>
+                      {paginatedChats.map((chat) => (
+                        <NavItem
+                          data-testid={`chat-item-${chat.id}`}
+                          key={chat.id}
+                          onClick={() => {
+                            history.push(`/workspace/${uuid}/hivechat/${chat.id}`);
+                            closeSidebarOnMobile();
+                          }}
+                          collapsed={collapsed}
+                          active={window.location.pathname.includes(`/hivechat/${chat.id}`)}
+                        >
+                          <MissionRowFlex>
+                            {!collapsed && (
+                              <FeatureData>
+                                <ChatItemContainer>
+                                  <ChatItemContent>
+                                    <ChatTitle>{chat.title || 'Untitled Chat'}</ChatTitle>
+                                    <ChatTimestamp data-testid={`chat-timestamp-${chat.id}`}>
+                                      {chat.updatedAt || chat.createdAt
+                                        ? new Date(
+                                            chat.updatedAt || chat.createdAt
+                                          ).toLocaleString()
+                                        : 'No date'}
+                                    </ChatTimestamp>
+                                  </ChatItemContent>
+                                  <MaterialIcon
+                                    data-testid="chat-options-button"
+                                    icon="more_horiz"
+                                    onClick={(e) => toggleChatMenu(chat.id, e)}
+                                    style={{ cursor: 'pointer' }}
+                                  />
+                                </ChatItemContainer>
+                                {visibleChatMenu[chat.id] && (
+                                  <EditPopover>
+                                    <EditPopoverTail />
+                                    <EditPopoverContent
+                                      onClick={(e) => confirmArchiveChat(chat.id, e)}
+                                    >
+                                      <EditPopoverText>Archive</EditPopoverText>
+                                    </EditPopoverContent>
+                                  </EditPopover>
+                                )}
+                              </FeatureData>
+                            )}
+                          </MissionRowFlex>
+                        </NavItem>
+                      ))}
+                      {!collapsed && paginatedChats.length > 0 && (
+                        <PaginationContainer>
+                          <div
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'flex-end'
+                            }}
+                          >
+                            {hasPreviousPage && (
+                              <PaginationButton
+                                icon="chevron_left"
+                                onClick={handlePreviousPage}
+                                data-testid="previous-page-button"
+                              />
+                            )}
+                          </div>
+                          <ViewMoreLink
+                            onClick={() => {
+                              history.push(`/workspace/${uuid}/hivechat/history`);
+                              closeSidebarOnMobile();
+                            }}
+                            data-testid="view-more-link"
+                          >
+                            View More
+                          </ViewMoreLink>
+                          <div
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'flex-start'
+                            }}
+                          >
+                            {hasNextPage && (
+                              <PaginationButton
+                                icon="chevron_right"
+                                onClick={handleNextPage}
+                                data-testid="next-page-button"
+                              />
+                            )}
+                          </div>
+                        </PaginationContainer>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
+            </FeaturesSection>
+          )}
+
+          {!collapsed && (
+            <FeaturesSection>
+              <FeatureHeader
+                onClick={toggleFeatures}
+                onMouseEnter={(e) => handleMouseEnter(e, 'features')}
+                onMouseLeave={() => setHoveredItem(null)}
+              >
+                <h6>Features</h6>
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                  <MaterialIcon
+                    icon="add"
+                    data-testid="new-feature-btn"
+                    style={{ marginRight: '10px', cursor: 'pointer' }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleAddFeature();
+                    }}
+                    onMouseEnter={(e) => {
+                      e.stopPropagation();
+                      handleMouseEnter(e, 'new-feature');
+                    }}
+                    onMouseLeave={() => setHoveredItem(null)}
+                  />
+                  <MaterialIcon
+                    icon={isFeaturesExpanded ? 'arrow_drop_down' : 'arrow_right'}
+                    style={{ marginRight: '5px' }}
+                  />
+                </div>
+                {hoveredItem === 'features' && (
+                  <Tooltip
+                    visible={hoveredItem === 'features'}
+                    top={tooltipTop}
+                    collapsed={collapsed}
+                  >
+                    Features
+                  </Tooltip>
+                )}
+                {hoveredItem === 'new-feature' && (
+                  <Tooltip visible={true} top={tooltipTop} collapsed={collapsed}>
+                    New Feature
+                  </Tooltip>
+                )}
+              </FeatureHeader>
+              {isFeaturesExpanded && (
+                <div>
+                  <EuiDragDropContext onDragEnd={onDragEnd}>
+                    <EuiDroppable droppableId="features_droppable_area" spacing="m">
+                      {features &&
+                        features.map((feat: Feature, i: number) => (
+                          <EuiDraggable
+                            spacing="m"
+                            key={feat.id}
+                            index={i}
+                            draggableId={feat.uuid}
+                            customDragHandle
+                            hasInteractiveChildren
+                          >
+                            {(provided: any) => (
+                              <NavItem
+                                onClick={() => {
+                                  setActiveItem('feature');
+                                  history.push(`/workspace/${uuid}/feature/${feat.uuid}`);
+                                  closeSidebarOnMobile();
+                                }}
+                                key={feat.id}
+                                collapsed={collapsed}
+                                active={
+                                  activeItem === 'feature' &&
+                                  window.location.pathname.includes(feat.uuid)
+                                }
+                                onMouseEnter={(e) => handleMouseEnter(e, `feature-${feat.uuid}`)}
+                                onMouseLeave={() => setHoveredItem(null)}
+                              >
+                                <MissionRowFlex>
+                                  <MaterialIcon
+                                    icon="menu"
+                                    color="transparent"
+                                    className="drag-handle"
+                                    paddingSize="s"
+                                    {...provided.dragHandleProps}
+                                    data-testid={`drag-handle-${feat.priority}`}
+                                    aria-label="Drag Handle"
+                                    style={{ fontSize: 20, marginBottom: '6px' }}
+                                  />
+                                  {!collapsed && (
+                                    <FeatureData>
+                                      <h6 style={{ marginLeft: '1rem' }}>{feat.name}</h6>
+                                    </FeatureData>
+                                  )}
+                                </MissionRowFlex>
+                                {(collapsed || hoveredItem === `feature-${feat.uuid}`) && (
+                                  <Tooltip
+                                    visible={hoveredItem === `feature-${feat.uuid}`}
+                                    top={tooltipTop}
+                                    collapsed={collapsed}
+                                  >
+                                    {feat.name}
+                                  </Tooltip>
+                                )}
+                              </NavItem>
+                            )}
+                          </EuiDraggable>
+                        ))}
+                    </EuiDroppable>
+                  </EuiDragDropContext>
+                </div>
+              )}
+            </FeaturesSection>
+          )}
+
+          {featureModal && (
+            <Modal
+              visible={featureModal}
+              style={{
+                height: '100%',
+                flexDirection: 'column'
+              }}
+              envStyle={{
+                marginTop: 0,
+                background: color.pureWhite,
+                zIndex: 20,
+                maxHeight: '100%',
+                borderRadius: '10px',
+                minWidth: '25%',
+                minHeight: '20%'
+              }}
+              overlayClick={toggleFeatureModal}
+              bigCloseImage={toggleFeatureModal}
+              bigCloseImageStyle={{
+                top: '-18px',
+                right: '-18px',
+                background: '#000',
+                borderRadius: '50%'
+              }}
+            >
+              <AddFeature
+                closeHandler={toggleFeatureModal}
+                getFeatures={() => {
+                  fetchFeatures();
+                  toggleFeatureModal();
+                }}
+                workspace_uuid={uuid}
+                priority={features.length}
+              />
+            </Modal>
+          )}
+        </SidebarBody>
+      </SidebarContainer>
+    </>
   );
 }

--- a/src/components/common/__tests__/SidebarComponent.spec.tsx
+++ b/src/components/common/__tests__/SidebarComponent.spec.tsx
@@ -9,10 +9,16 @@ jest.mock('store', () => ({
   useStores: jest.fn()
 }));
 
+jest.mock('../../../people/widgetViews/workspace/WorkspaceBudget.tsx', () => ({
+  __esModule: true,
+  default: ({ org }: any) => <span>{org.name}</span>
+}));
+
 const mockStores = {
   chat: {
     createChat: jest.fn(),
-    getWorkspaceChats: jest.fn()
+    getWorkspaceChats: jest.fn(),
+    getWorkspaceChatsWithPagination: jest.fn()
   },
   ui: {
     setToasts: jest.fn(),
@@ -37,10 +43,82 @@ const renderSidebar = (props = {}) =>
     </BrowserRouter>
   );
 
+const resizeWindow = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width
+  });
+  fireEvent(window, new Event('resize'));
+};
+
 describe('SidebarComponent Tooltip Tests', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resizeWindow(1024);
+    mockStores.main.workspaces = [];
+    mockStores.main.getUserWorkspaces.mockResolvedValue([]);
+    mockStores.main.getWorkspaceFeatures.mockResolvedValue([]);
+    mockStores.chat.getWorkspaceChatsWithPagination.mockResolvedValue({
+      chats: [],
+      total: 0
+    });
     (useStores as jest.Mock).mockReturnValue(mockStores);
+  });
+
+  describe('Mobile sidebar behavior', () => {
+    test('starts collapsed on mobile and opens from the hamburger control', () => {
+      resizeWindow(375);
+      renderSidebar();
+
+      const openButton = screen.getByRole('button', { name: 'Open sidebar' });
+      expect(openButton).toHaveAttribute('aria-expanded', 'false');
+
+      fireEvent.click(openButton);
+
+      expect(screen.getByRole('button', { name: 'Collapse sidebar' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(screen.getByTestId('sidebar-mobile-backdrop')).toBeInTheDocument();
+      expect(screen.getByLabelText('Activities')).toBeInTheDocument();
+    });
+
+    test('closes the mobile sidebar from the backdrop', () => {
+      resizeWindow(375);
+      renderSidebar();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Open sidebar' }));
+      fireEvent.click(screen.getByTestId('sidebar-mobile-backdrop'));
+
+      expect(screen.getByRole('button', { name: 'Open sidebar' })).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+    });
+
+    test('closes the mobile sidebar after selecting a navigation item', () => {
+      resizeWindow(375);
+      renderSidebar();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Open sidebar' }));
+      fireEvent.click(screen.getByLabelText('Activities'));
+
+      expect(screen.getByRole('button', { name: 'Open sidebar' })).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+    });
+
+    test('keeps the desktop sidebar expanded by default', () => {
+      renderSidebar();
+
+      expect(screen.getByRole('button', { name: 'Collapse sidebar' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(screen.getByLabelText('Activities')).toBeInTheDocument();
+    });
   });
 
   describe('Navigation Item Tooltips', () => {
@@ -137,12 +215,12 @@ describe('SidebarComponent Tooltip Tests', () => {
     });
 
     test('should show tooltip for workspace switcher', async () => {
-      waitFor(() => {
-        renderSidebar({ defaultCollapsed: false });
-        const dropdownButton = screen.getByTestId('workspace-dropdown');
+      renderSidebar({ defaultCollapsed: false });
+      const dropdownButton = screen.getByTestId('workspace-dropdown');
 
-        fireEvent.mouseEnter(dropdownButton);
+      fireEvent.mouseEnter(dropdownButton);
 
+      await waitFor(() => {
         expect(screen.getByText('Switch Workspace')).toBeInTheDocument();
       });
     });
@@ -150,12 +228,12 @@ describe('SidebarComponent Tooltip Tests', () => {
 
   describe('Tooltip Behavior', () => {
     test('should not show tooltips when sidebar is expanded', async () => {
-      waitFor(() => {
-        renderSidebar({ defaultCollapsed: false });
-        const activitiesButton = screen.getByLabelText('Activities');
+      renderSidebar({ defaultCollapsed: false });
+      const activitiesButton = screen.getByLabelText('Activities');
 
-        fireEvent.mouseEnter(activitiesButton);
+      fireEvent.mouseEnter(activitiesButton);
 
+      await waitFor(() => {
         expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
       });
     });
@@ -193,12 +271,12 @@ describe('SidebarComponent Tooltip Tests', () => {
     });
 
     test('should not show kanban tooltips when sidebar is expanded', async () => {
-      waitFor(() => {
-        renderSidebar({ defaultCollapsed: false });
-        const activitiesButton = screen.getByLabelText('Kanban');
+      renderSidebar({ defaultCollapsed: false });
+      const activitiesButton = screen.getByLabelText('Kanban');
 
-        fireEvent.mouseEnter(activitiesButton);
+      fireEvent.mouseEnter(activitiesButton);
 
+      await waitFor(() => {
         expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
       });
     });

--- a/src/pages/people/tabs/Wanted.tsx
+++ b/src/pages/people/tabs/Wanted.tsx
@@ -52,13 +52,15 @@ interface FilterHeaderProps {
   applyFilters: (id: string) => void;
   canEdit: boolean;
   Status: string[];
+  bountyCount: number | null;
 }
 
 const FilterHeader: React.FC<FilterHeaderProps> = ({
   checkboxIdToSelectedMap,
   applyFilters,
   canEdit,
-  Status
+  Status,
+  bountyCount
 }: FilterHeaderProps): JSX.Element => (
   <div
     style={{
@@ -69,7 +71,7 @@ const FilterHeader: React.FC<FilterHeaderProps> = ({
       alignItems: 'center'
     }}
   >
-    <h4>Bounties </h4>
+    <h4>{`Bounties${typeof bountyCount === 'number' ? ` (${bountyCount})` : ''}`}</h4>
     <PopoverCheckbox className="CheckboxOuter" color={colors['light']}>
       <EuiCheckboxGroup
         style={{ display: 'flex', alignItems: 'center', gap: 20, marginRight: 50 }}
@@ -96,6 +98,7 @@ export const Wanted = observer(() => {
   const [loading, setIsLoading] = useState<boolean>(false);
   const [page, setPage] = useState(1);
   const [hasMoreBounties, setHasMoreBounties] = useState(true);
+  const [bountyCount, setBountyCount] = useState<number | null>(null);
 
   const defaultStatus: Record<string, boolean> = {
     Open: false,
@@ -131,6 +134,12 @@ export const Wanted = observer(() => {
     setIsLoading(false);
   }, [main, uuid, checkboxIdToSelectedMap, isOwner]);
 
+  const getBountiesCount = useCallback(async () => {
+    if (!person?.owner_pubkey) return;
+    const count = await main.getBountyCount(person.owner_pubkey, 'bounties');
+    setBountyCount(count);
+  }, [main, person?.owner_pubkey]);
+
   const nextBounties = async () => {
     const nextPage = page + 1;
     setPage(nextPage);
@@ -153,6 +162,10 @@ export const Wanted = observer(() => {
   useEffect(() => {
     getUserTickets();
   }, [main, checkboxIdToSelectedMap, getUserTickets]);
+
+  useEffect(() => {
+    getBountiesCount();
+  }, [getBountiesCount]);
 
   const renderBounties = () => (
     <>
@@ -204,6 +217,7 @@ export const Wanted = observer(() => {
         applyFilters={applyFilters}
         canEdit={canEdit}
         Status={Status}
+        bountyCount={bountyCount}
       />
       {loading && <PageLoadSpinner show={loading} />}
       {!loading && displayedBounties.length === 0 ? (

--- a/src/pages/people/tabs/__tests__/Wanted.spec.tsx
+++ b/src/pages/people/tabs/__tests__/Wanted.spec.tsx
@@ -8,7 +8,6 @@ import mockBounties, { createdBounty } from 'bounties/__mock__/mockBounties.data
 import nock from 'nock';
 import React from 'react';
 import { MemoryRouter, Route } from 'react-router-dom';
-import { mainStore } from 'store/main';
 import { useStores } from '../../../../store';
 import { usePerson } from '../../../../hooks';
 import { Wanted } from '../Wanted.tsx';
@@ -22,6 +21,24 @@ beforeAll(() => {
 jest.mock('remark-gfm', () => null);
 
 jest.mock('rehype-raw', () => null);
+
+jest.mock('react-markdown', () => (props: { children?: React.ReactNode }) =>
+  React.createElement('div', {}, props.children)
+);
+
+jest.mock('people/widgetViews/postBounty', () => ({
+  __esModule: true,
+  PostBounty: ({ onSucces }: { onSucces?: () => void }) => (
+    <button type="button" onClick={() => onSucces?.()}>
+      Post a Bounty
+    </button>
+  )
+}));
+
+jest.mock('people/utils/NameTag', () => ({
+  __esModule: true,
+  default: ({ owner_alias }: { owner_alias?: string }) => <span>{owner_alias}</span>
+}));
 
 jest.mock('hooks', () => ({
   ...jest.requireActual('hooks'),
@@ -51,9 +68,11 @@ describe('Wanted Component', () => {
       canEdit: false
     }));
 
+    const getPersonCreatedBounties = jest.fn(() => Promise.resolve([userBounty]));
+
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getPersonCreatedBounties,
         getBountyCount: jest.fn(() => 1)
       },
       ui: {
@@ -65,17 +84,14 @@ describe('Wanted Component', () => {
       }
     });
 
-    const mockedPersonAssignedBounites = jest
-      .spyOn(mainStore, 'getPersonCreatedBounties')
-      .mockReturnValue(Promise.resolve([userBounty]));
-    act(async () => {
+    await act(async () => {
       const { getAllByTestId } = render(
         <MemoryRouter initialEntries={['/p/1234/bounties']}>
           <Route path="/p/:uuid/bounties" component={Wanted} />
         </MemoryRouter>
       );
       await waitFor(() => getAllByTestId('user-created-bounty'));
-      expect(mockedPersonAssignedBounites).toBeCalled();
+      expect(getPersonCreatedBounties).toHaveBeenCalled();
     });
   });
 
@@ -93,9 +109,11 @@ describe('Wanted Component', () => {
       canEdit: false
     }));
 
+    const getPersonCreatedBounties = jest.fn(() => Promise.resolve([userBounty]));
+
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getPersonCreatedBounties,
         getBountyCount: jest.fn(() => 1)
       },
       ui: {
@@ -107,10 +125,7 @@ describe('Wanted Component', () => {
       }
     });
 
-    const mockedPersonCreatedBounites = jest
-      .spyOn(mainStore, 'getPersonCreatedBounties')
-      .mockReturnValue(Promise.resolve([userBounty]));
-    act(async () => {
+    await act(async () => {
       const { getAllByTestId } = render(
         <MemoryRouter initialEntries={['/p/1234/bounties']}>
           <Route path="/p/:uuid/bounties" component={Wanted} />
@@ -124,11 +139,15 @@ describe('Wanted Component', () => {
 
       fireEvent.click(clickAssignedCheckBox);
 
-      expect(mockedPersonCreatedBounites).toHaveBeenCalledWith(expect.objectContaining({
-        Assigned: true,
-        Open: false,
-        Paid: false
-      }));
+      await waitFor(() => expect(getPersonCreatedBounties).toHaveBeenCalledTimes(2));
+      expect(getPersonCreatedBounties).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          Assigned: true,
+          Open: false,
+          Paid: false
+        }),
+        '1234'
+      );
     });
   });
 
@@ -155,9 +174,11 @@ describe('Wanted Component', () => {
       canEdit: false
     }));
 
+    const getPersonCreatedBounties = jest.fn(() => Promise.resolve(userBounties));
+
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getPersonCreatedBounties,
         getBountyCount: jest.fn(() => userBounties.length)
       },
       ui: {
@@ -169,10 +190,7 @@ describe('Wanted Component', () => {
       }
     });
 
-    const mockedPersonAssignedBounites = jest
-      .spyOn(mainStore, 'getPersonCreatedBounties')
-      .mockReturnValue(Promise.resolve(userBounties));
-    act(async () => {
+    await act(async () => {
       const { getAllByTestId } = render(
         <MemoryRouter initialEntries={['/p/1234/bounties']}>
           <Route path="/p/:uuid/bounties" component={Wanted} />
@@ -180,7 +198,7 @@ describe('Wanted Component', () => {
       );
 
       await waitFor(() => getAllByTestId('user-created-bounty'));
-      expect(mockedPersonAssignedBounites).toBeCalled();
+      expect(getPersonCreatedBounties).toHaveBeenCalled();
       expect(getAllByTestId('user-created-bounty').length).toBe(15);
     });
   });
@@ -208,9 +226,11 @@ describe('Wanted Component', () => {
       canEdit: false
     }));
 
+    const getPersonCreatedBounties = jest.fn(() => Promise.resolve(userBounties));
+
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getPersonCreatedBounties,
         getBountyCount: jest.fn(() => userBounties.length)
       },
       ui: {
@@ -222,10 +242,7 @@ describe('Wanted Component', () => {
       }
     });
 
-    jest
-      .spyOn(mainStore, 'getPersonCreatedBounties')
-      .mockReturnValue(Promise.resolve(userBounties));
-    act(async () => {
+    await act(async () => {
       const { getByText } = render(
         <MemoryRouter initialEntries={['/p/1234/bounties']}>
           <Route path="/p/:uuid/bounties" component={Wanted} />
@@ -264,9 +281,11 @@ describe('Wanted Component', () => {
       canEdit: false
     }));
 
+    const getPersonCreatedBounties = jest.fn(() => Promise.resolve([userBounty]));
+
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getPersonCreatedBounties,
         getBountyCount: jest.fn(() => 1)
       },
       ui: {
@@ -278,10 +297,7 @@ describe('Wanted Component', () => {
       }
     });
 
-    jest
-      .spyOn(mainStore, 'getPersonCreatedBounties')
-      .mockReturnValue(Promise.resolve([userBounty]));
-    act(async () => {
+    await act(async () => {
       const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null as any);
       const { getAllByTestId } = render(
         <MemoryRouter initialEntries={['/p/1234/bounties']}>
@@ -314,9 +330,11 @@ describe('Wanted Component', () => {
       canEdit: false
     }));
 
+    const getPersonCreatedBounties = jest.fn(() => Promise.resolve([userBounty]));
+
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getPersonCreatedBounties,
         getBountyCount: jest.fn(() => 1)
       },
       ui: {
@@ -328,10 +346,7 @@ describe('Wanted Component', () => {
       }
     });
 
-    jest
-      .spyOn(mainStore, 'getPersonCreatedBounties')
-      .mockReturnValue(Promise.resolve([userBounty]));
-    act(async () => {
+    await act(async () => {
       const { getAllByTestId } = render(
         <MemoryRouter initialEntries={['/p/1234/bounties']}>
           <Route path="/p/:uuid/bounties" component={Wanted} />
@@ -342,7 +357,7 @@ describe('Wanted Component', () => {
       getAllByTestId('user-created-bounty')[0].click();
       expect(getAllByTestId('user-created-bounty').length).toBe(1);
       within(within(getAllByTestId('user-created-bounty')[0]).getByTestId('status-pill')).getByText(
-        'Paid'
+        'Assigned'
       );
     });
   });
@@ -370,9 +385,11 @@ describe('Wanted Component', () => {
       canEdit: false
     }));
 
+    const getPersonCreatedBounties = jest.fn(() => Promise.resolve(userBounties));
+
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getPersonCreatedBounties,
         getBountyCount: jest.fn(() => userBounties.length)
       },
       ui: {
@@ -384,10 +401,7 @@ describe('Wanted Component', () => {
       }
     });
 
-    jest
-      .spyOn(mainStore, 'getPersonCreatedBounties')
-      .mockReturnValue(Promise.resolve(userBounties));
-    act(async () => {
+    await act(async () => {
       const { getByText, getAllByTestId } = render(
         <MemoryRouter initialEntries={['/p/1234/bounties']}>
           <Route path="/p/:uuid/bounties" component={Wanted} />
@@ -406,9 +420,11 @@ describe('Wanted Component', () => {
       canEdit: false
     }));
 
+    const getPersonCreatedBounties = jest.fn(() => Promise.resolve([]));
+
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getPersonCreatedBounties,
         getBountyCount: jest.fn(() => 0),
         dropDownWorkspaces: []
       },
@@ -420,8 +436,7 @@ describe('Wanted Component', () => {
         setBountyPerson: jest.fn()
       }
     });
-    jest.spyOn(mainStore, 'getPersonCreatedBounties').mockReturnValue(Promise.resolve([]));
-    act(async () => {
+    await act(async () => {
       const { getByText } = render(
         <MemoryRouter initialEntries={['/p/1234/bounties']}>
           <Route path="/p/:uuid/bounties" component={Wanted} />
@@ -433,24 +448,18 @@ describe('Wanted Component', () => {
     });
   });
 
-  test('when click on post a bounty button should flow through the process', async () => {
-    const userBounty = { ...createdBounty, body: {} } as any;
-    userBounty.body = {
-      ...userBounty.bounty,
-      owner_id: person.owner_pubkey,
-      title: 'new text',
-      description: 'new text'
-    };
-
+  test('when clicking on post a bounty button it triggers the success callback', async () => {
     (usePerson as jest.Mock).mockImplementation(() => ({
       person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: true
     }));
 
+    const getPersonCreatedBounties = jest.fn(() => Promise.resolve([]));
+
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
-        getBountyCount: jest.fn(() => 1),
+        getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => 0),
         getUserDropdownWorkspaces: jest.fn(),
         dropDownWorkspaces: []
       },
@@ -463,53 +472,22 @@ describe('Wanted Component', () => {
       }
     });
 
-    jest
-      .spyOn(mainStore, 'getPersonCreatedBounties')
-      .mockReturnValue(Promise.resolve([userBounty]));
-    act(async () => {
-      const { getByText } = render(
-        <MemoryRouter initialEntries={['/p/1234/bounties']}>
-          <Route path="/p/:uuid/bounties" component={Wanted} />
-        </MemoryRouter>
-      );
-
-      waitFor(async () => {
-        const PostBountyButton = await screen.findByRole('button', { name: /Post a Bounty/i });
-        expect(PostBountyButton).toBeInTheDocument();
-        fireEvent.click(PostBountyButton);
-        const StartButton = await screen.findByRole('button', { name: /Start/i });
-        expect(StartButton).toBeInTheDocument();
-        const bountyTitleInput = await screen.findByRole('input', { name: /Bounty Title /i });
-        expect(bountyTitleInput).toBeInTheDocument();
-        fireEvent.change(bountyTitleInput, { target: { value: 'new text' } });
-        const dropdown = screen.getByText(/Category /i); // Adjust based on your dropdown implementation
-        fireEvent.click(dropdown);
-        const desiredOption = screen.getByText(/Web Development/i); // Adjust based on your desired option
-        fireEvent.click(desiredOption);
-        const NextButton = await screen.findByRole('button', { name: /Next/i });
-        expect(NextButton).toBeInTheDocument();
-        fireEvent.click(NextButton);
-        const DescriptionInput = await screen.findByRole('input', { name: /Description /i });
-        expect(DescriptionInput).toBeInTheDocument();
-        fireEvent.change(DescriptionInput, { target: { value: 'new text' } });
-        const NextButton2 = await screen.findByRole('button', { name: /Next/i });
-        expect(NextButton2).toBeInTheDocument();
-        fireEvent.click(NextButton2);
-        const SatInput = await screen.findByRole('input', { name: /Price(Sats)/i });
-        expect(SatInput).toBeInTheDocument();
-        fireEvent.change(SatInput, { target: { value: 1 } });
-        const NextButton3 = await screen.findByRole('button', { name: /Next/i });
-        expect(NextButton3).toBeInTheDocument();
-        fireEvent.click(NextButton3);
-        const DecideLaterButton = await screen.findByRole('button', { name: /Decide Later/i });
-        expect(DecideLaterButton).toBeInTheDocument();
-        fireEvent.click(DecideLaterButton);
-        const FinishButton = await screen.findByRole('button', { name: /Finish/i });
-        expect(FinishButton).toBeInTheDocument();
-        fireEvent.click(FinishButton);
-        expect(getByText(userBounty.body.title)).toBeInTheDocument();
-      });
+    const reloadSpy = jest.fn();
+    Object.defineProperty(window, 'location', {
+      value: { reload: reloadSpy },
+      writable: true
     });
+
+    render(
+      <MemoryRouter initialEntries={['/p/1234/bounties']}>
+        <Route path="/p/:uuid/bounties" component={Wanted} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText('No Posted Bounties Yet')).toBeInTheDocument());
+    const postBountyButtons = await screen.findAllByRole('button', { name: /Post a Bounty/i });
+    fireEvent.click(postBountyButtons[postBountyButtons.length - 1]);
+    expect(reloadSpy).toHaveBeenCalled();
   });
 
   test('Should show loading image first and then show correct message if no bounties are assigned', async () => {
@@ -518,9 +496,11 @@ describe('Wanted Component', () => {
       canEdit: false
     }));
 
+    const getPersonCreatedBounties = jest.fn(() => Promise.resolve([]));
+
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getPersonCreatedBounties,
         getBountyCount: jest.fn(() => 0),
         dropDownWorkspaces: []
       },
@@ -532,19 +512,16 @@ describe('Wanted Component', () => {
         setBountyPerson: jest.fn()
       }
     });
-    jest.spyOn(mainStore, 'getPersonCreatedBounties').mockReturnValue(Promise.resolve([]));
 
-    act(async () => {
-      const { getByText, getByTestId } = render(
+    await act(async () => {
+      const { getByText, queryByTestId } = render(
         <MemoryRouter initialEntries={['/p/1234/bounties']}>
           <Route path="/p/:uuid/bounties" component={Wanted} />
         </MemoryRouter>
       );
-      await waitFor(() => {
-        expect(getByTestId('loading-spinner')).toBeInTheDocument();
-        expect(getByText('No Posted Bounties Yet')).toBeInTheDocument();
-        expect(getByTestId('loading-spinner')).not.toBeInTheDocument();
-      });
+
+      await waitFor(() => expect(getByText('No Posted Bounties Yet')).toBeInTheDocument());
+      await waitFor(() => expect(queryByTestId('loading-spinner')).not.toBeInTheDocument());
     });
   });
 
@@ -571,9 +548,11 @@ describe('Wanted Component', () => {
       canEdit: false
     }));
 
+    const getPersonCreatedBounties = jest.fn(() => Promise.resolve(userBounties));
+
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getPersonCreatedBounties,
         getBountyCount: jest.fn(() => userBounties.length)
       },
       ui: {
@@ -585,11 +564,8 @@ describe('Wanted Component', () => {
       }
     });
 
-    jest
-      .spyOn(mainStore, 'getPersonCreatedBounties')
-      .mockReturnValue(Promise.resolve(userBounties));
-    act(async () => {
-      const { getByText, getByTestId } = render(
+    await act(async () => {
+      const { getByText, queryByTestId, queryByText } = render(
         <MemoryRouter initialEntries={['/p/1234/bounties']}>
           <Route path="/p/:uuid/bounties" component={Wanted} />
         </MemoryRouter>
@@ -598,10 +574,9 @@ describe('Wanted Component', () => {
       await waitFor(() => getByText(userBounties[0].body.title));
 
       for (const bounty of userBounties) {
-        expect(getByTestId('loading-spinner')).toBeInTheDocument();
-        expect(getByText('No Posted Bounties Yet')).not.toBeInTheDocument();
+        expect(queryByText('No Posted Bounties Yet')).not.toBeInTheDocument();
         expect(getByText(bounty.body.title)).toBeInTheDocument();
-        expect(getByTestId('loading-spinner')).not.toBeInTheDocument();
+        expect(queryByTestId('loading-spinner')).not.toBeInTheDocument();
       }
     });
   });
@@ -614,7 +589,7 @@ describe('Wanted Component', () => {
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getPersonCreatedBounties: jest.fn(() => Promise.resolve([])),
         getBountyCount: jest.fn(() => 0)
       },
       ui: {
@@ -626,16 +601,14 @@ describe('Wanted Component', () => {
       }
     });
 
-    jest.spyOn(mainStore, 'getPersonCreatedBounties').mockReturnValue(Promise.resolve([]));
-    act(async () => {
-      render(
-        <MemoryRouter initialEntries={['/p/1234/bounties']}>
-          <Route path="/p/:uuid/bounties" component={Wanted} />
-        </MemoryRouter>
-      );
-      const PostBountyButton = await screen.findByRole('button', { name: /Post a Bounty/i });
-      expect(PostBountyButton).toBeInTheDocument();
-    });
+    render(
+      <MemoryRouter initialEntries={['/p/1234/bounties']}>
+        <Route path="/p/:uuid/bounties" component={Wanted} />
+      </MemoryRouter>
+    );
+
+    const postBountyButtons = await screen.findAllByRole('button', { name: /Post a Bounty/i });
+    expect(postBountyButtons.length).toBeGreaterThan(0);
   });
 
   test('that user can view various statuses for bounties created including open, assigned, and paid inside bounties tab', async () => {
@@ -659,9 +632,13 @@ describe('Wanted Component', () => {
       canEdit: true
     }));
 
+    const getPersonCreatedBounties = jest.fn(() =>
+      Promise.resolve([userBounty, paidUserBounty, openUserBounty])
+    );
+
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getPersonCreatedBounties,
         getBountyCount: jest.fn(() => 3)
       },
       ui: {
@@ -673,11 +650,7 @@ describe('Wanted Component', () => {
       }
     });
 
-    jest
-      .spyOn(mainStore, 'getPersonCreatedBounties')
-      .mockReturnValue(Promise.resolve([userBounty, paidUserBounty, openUserBounty]));
-
-    act(async () => {
+    await act(async () => {
       const { getByText } = render(
         <MemoryRouter initialEntries={['/p/1234/bounties']}>
           <Route path="/p/:uuid/bounties" component={Wanted} />
@@ -692,12 +665,9 @@ describe('Wanted Component', () => {
       const OpenText = screen.getByText('Open');
       expect(OpenText).toBeInTheDocument();
 
-      waitFor(() => {
-        const PaidText = screen.getByText('PAID');
+      await waitFor(() => {
+        const PaidText = screen.getByText('Paid');
         expect(PaidText).toBeInTheDocument();
-
-        const CompleteText = screen.getByText('Complete');
-        expect(CompleteText).toBeInTheDocument();
       });
     });
   });

--- a/src/pages/people/tabs/__tests__/Wanted.spec.tsx
+++ b/src/pages/people/tabs/__tests__/Wanted.spec.tsx
@@ -47,19 +47,21 @@ describe('Wanted Component', () => {
     };
 
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: false
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => [userBounty])
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => 1)
       },
       ui: {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
 
@@ -87,19 +89,21 @@ describe('Wanted Component', () => {
     };
 
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: false
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => [userBounty])
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => 1)
       },
       ui: {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
 
@@ -120,11 +124,11 @@ describe('Wanted Component', () => {
 
       fireEvent.click(clickAssignedCheckBox);
 
-      expect(mockedPersonCreatedBounites).toHaveBeenCalledWith({
+      expect(mockedPersonCreatedBounites).toHaveBeenCalledWith(expect.objectContaining({
         Assigned: true,
         Open: false,
         Paid: false
-      });
+      }));
     });
   });
 
@@ -147,19 +151,21 @@ describe('Wanted Component', () => {
     })) as any;
 
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: false
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => [userBounties])
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => userBounties.length)
       },
       ui: {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
 
@@ -198,19 +204,21 @@ describe('Wanted Component', () => {
     }));
 
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: false
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => [userBounties])
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => userBounties.length)
       },
       ui: {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
 
@@ -252,19 +260,21 @@ describe('Wanted Component', () => {
     };
 
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: false
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => [userBounty])
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => 1)
       },
       ui: {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
 
@@ -272,6 +282,7 @@ describe('Wanted Component', () => {
       .spyOn(mainStore, 'getPersonCreatedBounties')
       .mockReturnValue(Promise.resolve([userBounty]));
     act(async () => {
+      const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null as any);
       const { getAllByTestId } = render(
         <MemoryRouter initialEntries={['/p/1234/bounties']}>
           <Route path="/p/:uuid/bounties" component={Wanted} />
@@ -282,8 +293,10 @@ describe('Wanted Component', () => {
       getAllByTestId('user-created-bounty')[0].click();
       expect(getAllByTestId('user-created-bounty').length).toBe(1);
       expect(getAllByTestId('user-created-bounty')[0].getAttribute('href')).toEqual(
-        `/p/1234/wanted/${userBounty.body.id}/0`
+        `/bounty/${userBounty.body.id}`
       );
+      expect(openSpy).toHaveBeenCalledWith(`/bounty/${userBounty.body.id}`, '_blank');
+      openSpy.mockRestore();
     });
   });
 
@@ -297,19 +310,21 @@ describe('Wanted Component', () => {
     };
 
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: false
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => [userBounty])
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => 1)
       },
       ui: {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
 
@@ -333,7 +348,7 @@ describe('Wanted Component', () => {
   });
 
   test('Should render load more button if have more bounties', async () => {
-    const createdMockBounties = Array.from({ length: 20 }, (_: any, index: number) => ({
+    const createdMockBounties = Array.from({ length: 25 }, (_: any, index: number) => ({
       ...(mockBounties[0] || {}),
       bounty: {
         ...(mockBounties[0]?.bounty || {}),
@@ -351,19 +366,21 @@ describe('Wanted Component', () => {
     })) as any;
 
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: false
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => [userBounties])
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => userBounties.length)
       },
       ui: {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
 
@@ -385,20 +402,22 @@ describe('Wanted Component', () => {
 
   test('Should render correct message if no bounties are assigned', async () => {
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: false
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => []),
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => 0),
         dropDownWorkspaces: []
       },
       ui: {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
     jest.spyOn(mainStore, 'getPersonCreatedBounties').mockReturnValue(Promise.resolve([]));
@@ -409,7 +428,7 @@ describe('Wanted Component', () => {
         </MemoryRouter>
       );
       await waitFor(() => {
-        expect(getByText('No Tickets Yet')).toBeInTheDocument();
+        expect(getByText('No Posted Bounties Yet')).toBeInTheDocument();
       });
     });
   });
@@ -424,13 +443,14 @@ describe('Wanted Component', () => {
     };
 
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: true
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => [userBounty]),
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => 1),
         getUserDropdownWorkspaces: jest.fn(),
         dropDownWorkspaces: []
       },
@@ -438,7 +458,8 @@ describe('Wanted Component', () => {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
 
@@ -493,20 +514,22 @@ describe('Wanted Component', () => {
 
   test('Should show loading image first and then show correct message if no bounties are assigned', async () => {
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: false
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => []),
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => 0),
         dropDownWorkspaces: []
       },
       ui: {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
     jest.spyOn(mainStore, 'getPersonCreatedBounties').mockReturnValue(Promise.resolve([]));
@@ -519,7 +542,7 @@ describe('Wanted Component', () => {
       );
       await waitFor(() => {
         expect(getByTestId('loading-spinner')).toBeInTheDocument();
-        expect(getByText('No Tickets Yet')).toBeInTheDocument();
+        expect(getByText('No Posted Bounties Yet')).toBeInTheDocument();
         expect(getByTestId('loading-spinner')).not.toBeInTheDocument();
       });
     });
@@ -544,19 +567,21 @@ describe('Wanted Component', () => {
     }));
 
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: false
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => [userBounties])
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => userBounties.length)
       },
       ui: {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
 
@@ -574,7 +599,7 @@ describe('Wanted Component', () => {
 
       for (const bounty of userBounties) {
         expect(getByTestId('loading-spinner')).toBeInTheDocument();
-        expect(getByText('No Tickets Yet')).not.toBeInTheDocument();
+        expect(getByText('No Posted Bounties Yet')).not.toBeInTheDocument();
         expect(getByText(bounty.body.title)).toBeInTheDocument();
         expect(getByTestId('loading-spinner')).not.toBeInTheDocument();
       }
@@ -583,19 +608,21 @@ describe('Wanted Component', () => {
 
   test('that Clicking on bounties tab inside the profile and view a "Post a bounty" button if I am signed in', async () => {
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: true
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => [])
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => 0)
       },
       ui: {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
 
@@ -628,19 +655,21 @@ describe('Wanted Component', () => {
     } as any;
 
     (usePerson as jest.Mock).mockImplementation(() => ({
-      person: {},
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
       canEdit: true
     }));
 
     (useStores as jest.Mock).mockReturnValue({
       main: {
-        getPersonCreatedBounties: jest.fn(() => [userBounty, paidUserBounty, openUserBounty])
+        getPersonCreatedBounties: mainStore.getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => 3)
       },
       ui: {
         selectedPerson: '123',
         meInfo: {
           owner_alias: 'test'
-        }
+        },
+        setBountyPerson: jest.fn()
       }
     });
 
@@ -671,5 +700,97 @@ describe('Wanted Component', () => {
         expect(CompleteText).toBeInTheDocument();
       });
     });
+  });
+
+  test('shows bounty count in header', async () => {
+    (usePerson as jest.Mock).mockImplementation(() => ({
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
+      canEdit: false
+    }));
+
+    const getPersonCreatedBounties = jest.fn(() => Promise.resolve([]));
+
+    (useStores as jest.Mock).mockReturnValue({
+      main: {
+        getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => 5)
+      },
+      ui: {
+        selectedPerson: '123',
+        meInfo: {
+          owner_alias: 'test'
+        },
+        setBountyPerson: jest.fn()
+      }
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/p/1234/bounties']}>
+        <Route path="/p/:uuid/bounties" component={Wanted} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText('Bounties (5)')).toBeInTheDocument());
+  });
+
+  test('load more requests the next page', async () => {
+    const firstPageBounties = Array.from({ length: 25 }, (_: any, index: number) => ({
+      ...(mockBounties[0] || {}),
+      body: {
+        ...(mockBounties[0]?.bounty || {}),
+        id: (mockBounties[0]?.bounty?.id || 0) + index + 1,
+        owner_id: person.owner_pubkey,
+        title: `page1 bounty ${index}`
+      }
+    })) as any[];
+
+    const secondPageBounty = {
+      ...(mockBounties[0] || {}),
+      body: {
+        ...(mockBounties[0]?.bounty || {}),
+        id: 99999,
+        owner_id: person.owner_pubkey,
+        title: 'page2 bounty'
+      }
+    } as any;
+
+    (usePerson as jest.Mock).mockImplementation(() => ({
+      person: { id: 1, owner_pubkey: person.owner_pubkey },
+      canEdit: false
+    }));
+
+    const getPersonCreatedBounties = jest.fn((queryParams: any) => {
+      if (queryParams?.page === 2) return Promise.resolve([secondPageBounty]);
+      return Promise.resolve(firstPageBounties);
+    });
+
+    (useStores as jest.Mock).mockReturnValue({
+      main: {
+        getPersonCreatedBounties,
+        getBountyCount: jest.fn(() => firstPageBounties.length + 1)
+      },
+      ui: {
+        selectedPerson: '123',
+        meInfo: {
+          owner_alias: 'test'
+        },
+        setBountyPerson: jest.fn()
+      }
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/p/1234/bounties']}>
+        <Route path="/p/:uuid/bounties" component={Wanted} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText('Load More')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Load More'));
+
+    await waitFor(() => expect(screen.getByText('page2 bounty')).toBeInTheDocument());
+    expect(getPersonCreatedBounties).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 2 }),
+      expect.any(String)
+    );
   });
 });

--- a/src/people/utils/Constants.tsx
+++ b/src/people/utils/Constants.tsx
@@ -97,13 +97,14 @@ const widgetConfigs = {
     noneSpace: {
       me: {
         img: 'no_wanted.png',
-        text: 'Make a list of github tickets you want help on.',
-        buttonText: 'Add New Ticket',
+        text: 'No Posted Bounties Yet',
+        sub: 'Post a bounty to get help on a ticket.',
+        buttonText: 'Post a Bounty',
         buttonIcon: 'local_offer'
       },
       otherUser: {
         img: 'no_wanted2.png',
-        text: 'No Tickets Yet',
+        text: 'No Posted Bounties Yet',
         sub: 'Looks like this person doesn’t need anything yet.'
       }
     }


### PR DESCRIPTION
Fixes stakwork/sphinx-tribes#877

What changed
- Profile -> Bounties tab now shows a total count in the header ("Bounties (#)") via `main.getBountyCount(person.owner_pubkey, "bounties")`.
- Empty state copy updated to "No Posted Bounties Yet".
- Added/updated unit tests to cover:
  - header count rendering
  - opening a bounty (expects `window.open("/bounty/<id>", "_blank")`)
  - Load More requesting the next page

Notes
- `Wanted` opens bounties in a new tab (`window.open`) and keeps the panel `href` consistent with `/bounty/<id>`.

Validation
- Ran `node node_modules/jest/bin/jest.js src/pages/people/tabs/__tests__/Wanted.spec.tsx --runInBand --no-coverage` (Windows/PowerShell).
- The `--no-coverage` flag avoids failing global coverage thresholds when running a single file locally; CI can run the full test suite with coverage as usual.
