### PR TITLE
test(profile): cover assigned bounties count

### DIFF
--- a/src/pages/people/tabs/__tests__/index.spec.tsx
+++ b/src/pages/people/tabs/__tests__/index.spec.tsx
@@ -1,10 +1,58 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render, waitFor, within } from '@testing-library/react';
+import { usePerson } from 'hooks';
 import { MemoryRouter, Route } from 'react-router-dom';
+import { useStores } from 'store';
 import { TabsPages } from '..';
 
+jest.mock('hooks', () => ({
+  useBrowserTabTitle: jest.fn(),
+  useIsMobile: jest.fn(() => false),
+  usePerson: jest.fn()
+}));
+
+jest.mock('store', () => ({
+  useStores: jest.fn()
+}));
+
+jest.mock('people/widgetViews/RenderWidgets', () => ({
+  __esModule: true,
+  default: ({ widget }: { widget: string }) => <div data-testid={`widget-${widget}`} />
+}));
+
+jest.mock('../Wanted', () => ({
+  Wanted: () => <div data-testid="wanted-widget" />
+}));
+
 describe('TabsPages Component', () => {
+  const getBountyCount = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    getBountyCount.mockImplementation((_personKey: string, name: string) =>
+      Promise.resolve(name === 'assigned' ? 7 : 3)
+    );
+
+    (useStores as jest.Mock).mockReturnValue({
+      main: {
+        getBountyCount
+      },
+      ui: {
+        selectedPerson: 1
+      }
+    });
+
+    (usePerson as jest.Mock).mockReturnValue({
+      person: {
+        owner_pubkey: 'owner-pubkey',
+        extras: {}
+      },
+      canEdit: false
+    });
+  });
+
   test('Test that clicking on the profile and view the title sections for org, badges, bounties, assigned', async () => {
     render(
       <MemoryRouter initialEntries={['/p/1234/workspaces']}>
@@ -18,5 +66,20 @@ describe('TabsPages Component', () => {
       expect(screen.getByText('Bounties')).toBeInTheDocument();
       expect(screen.getByText('Assigned Bounties')).toBeInTheDocument();
     });
+  });
+
+  test('renders assigned bounties count next to the assigned tab title', async () => {
+    render(
+      <MemoryRouter initialEntries={['/p/1234/assigned']}>
+        <Route path="/p/:uuid/assigned" component={TabsPages} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(getBountyCount).toHaveBeenCalledWith('owner-pubkey', 'assigned')
+    );
+
+    const assignedTab = screen.getByTestId('Assigned Bounties-tab');
+    expect(within(assignedTab).getByText('7')).toBeInTheDocument();
   });
 });

--- a/src/people/widgetViews/UserTicketsView.spec.tsx
+++ b/src/people/widgetViews/UserTicketsView.spec.tsx
@@ -12,6 +12,16 @@ import { mainStore } from 'store/main';
 import UserTickets from './UserTicketsView';
 
 beforeAll(() => {
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      clear: jest.fn(),
+      getItem: jest.fn(),
+      removeItem: jest.fn(),
+      setItem: jest.fn()
+    },
+    writable: true
+  });
+
   nock.disableNetConnect();
   setupStore();
   mockUsehistory();


### PR DESCRIPTION
Fixes stakwork/sphinx-tribes#878

What changed
- Added focused profile tab coverage for the Assigned Bounties tab count.
- Mocked heavy widget rendering and store/hooks so the tab test validates tab behavior directly instead of failing on unrelated markdown/widget imports.
- Verifies `main.getBountyCount(owner_pubkey, "assigned")` is called and the assigned count renders next to the Assigned Bounties tab title.
- Stabilized the existing assigned-bounties view spec by providing `window.localStorage`, so its 10 existing workflow assertions exit cleanly instead of passing assertions and then crashing during MobX persistence cleanup.

Validation
- Ran `node node_modules/jest/bin/jest.js src/pages/people/tabs/__tests__/index.spec.tsx --runInBand --no-coverage --silent`.
- Ran `node node_modules/jest/bin/jest.js src/pages/people/tabs/__tests__/index.spec.tsx src/people/widgetViews/UserTicketsView.spec.tsx --runInBand --no-coverage --silent`.
- Ran `git diff --check HEAD~1..HEAD`.
