### PR TITLE
test(bounties): cover organization bounty payments

### DIFF
--- a/src/people/WorkSpacePlanner/BountyCard/BountyCard.test.tsx
+++ b/src/people/WorkSpacePlanner/BountyCard/BountyCard.test.tsx
@@ -1,10 +1,44 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BountyCardStatus, Feature } from 'store/interface';
 import { Workspace } from 'store/interface';
 import '@testing-library/jest-dom/extend-expect';
 import { Phase } from 'people/widgetViews/workspace/interface';
 import React from 'react';
+import { useStores } from 'store';
 import BountyCardComponent from '.';
+
+jest.mock('store', () => ({
+  useStores: jest.fn()
+}));
+
+jest.mock('components/common', () => {
+  const React = require('react');
+
+  return {
+    PaymentConfirmationModal: ({ onClose, onConfirmPayment }: any) =>
+      React.createElement(
+        'div',
+        { 'data-testid': 'payment-confirmation-modal' },
+        React.createElement('button', { onClick: onClose }, 'Cancel'),
+        React.createElement('button', { onClick: onConfirmPayment }, 'Confirm')
+      )
+  };
+});
+
+jest.mock('@elastic/eui', () => {
+  const React = require('react');
+
+  return {
+    EuiGlobalToastList: ({ toasts }: any) =>
+      React.createElement(
+        'div',
+        { 'data-testid': 'toast-list' },
+        toasts.map((toast: any) =>
+          React.createElement('div', { key: toast.id }, toast.title)
+        )
+      )
+  };
+});
 
 const mockFeature: Feature = {
   id: 2,
@@ -67,9 +101,46 @@ const mockBountyCard = {
 };
 
 describe('BountyCardComponent', () => {
+  const getBountyById = jest.fn();
+  const getWorkspaceBudget = jest.fn();
+  const makeBountyPayment = jest.fn();
+  const pollInvoice = jest.fn();
+  const getLnInvoice = jest.fn();
+  const setKeysendInvoice = jest.fn();
+  const onPayBounty = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
+
+    getBountyById.mockResolvedValue([
+      {
+        created: '2024-02-15',
+        person: {
+          owner_pubkey: 'hunter-pubkey',
+          owner_route_hint: 'hunter-route'
+        }
+      }
+    ]);
+    getWorkspaceBudget.mockResolvedValue({ current_budget: 1000 });
+    makeBountyPayment.mockResolvedValue({});
+
+    (useStores as jest.Mock).mockReturnValue({
+      ui: {
+        meInfo: {
+          websocketToken: 'socket-token'
+        }
+      },
+      main: {
+        getBountyById,
+        getWorkspaceBudget,
+        makeBountyPayment,
+        pollInvoice,
+        getLnInvoice,
+        setKeysendInvoice
+      }
+    });
   });
+
   it('displays all core bounty information correctly', () => {
     const { getByText } = render(<BountyCardComponent {...mockBountyCard} status="COMPLETED" />);
 
@@ -80,5 +151,68 @@ describe('BountyCardComponent', () => {
   it('hides action menu for non-actionable statuses', () => {
     const { queryByTestId } = render(<BountyCardComponent {...mockBountyCard} />);
     expect(queryByTestId('feature-name-btn')).not.toBeInTheDocument();
+  });
+
+  it('opens payment confirmation from the Pay Bounty action', async () => {
+    render(
+      <BountyCardComponent
+        {...mockBountyCard}
+        status="COMPLETED"
+        bounty_price={500}
+        onPayBounty={onPayBounty}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Pay Bounty'));
+
+    expect(screen.getByTestId('payment-confirmation-modal')).toBeInTheDocument();
+  });
+
+  it('pays through the organization when workspace budget covers the bounty price', async () => {
+    render(
+      <BountyCardComponent
+        {...mockBountyCard}
+        status="COMPLETED"
+        bounty_price={500}
+        onPayBounty={onPayBounty}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Pay Bounty'));
+    fireEvent.click(screen.getByText('Confirm'));
+
+    await waitFor(() => {
+      expect(getWorkspaceBudget).toHaveBeenCalledWith('ws-789');
+      expect(makeBountyPayment).toHaveBeenCalledWith({
+        id: 456,
+        websocket_token: 'socket-token'
+      });
+      expect(onPayBounty).toHaveBeenCalledWith('456');
+    });
+
+    expect(screen.getByText('Paid successfully')).toBeInTheDocument();
+  });
+
+  it('shows an insufficient funds error when organization budget is too low', async () => {
+    getWorkspaceBudget.mockResolvedValue({ current_budget: 100 });
+
+    render(
+      <BountyCardComponent
+        {...mockBountyCard}
+        status="COMPLETED"
+        bounty_price={500}
+        onPayBounty={onPayBounty}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Pay Bounty'));
+    fireEvent.click(screen.getByText('Confirm'));
+
+    await waitFor(() => {
+      expect(getWorkspaceBudget).toHaveBeenCalledWith('ws-789');
+      expect(makeBountyPayment).not.toHaveBeenCalled();
+    });
+
+    expect(screen.getByText('Insufficient funds in the workspace.')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add focused coverage for the workspace bounty card Pay Bounty action
- verify the payment confirmation opens for actionable bounty statuses
- verify organization budget success calls `makeBountyPayment` and invokes the paid callback
- verify low organization budget shows the insufficient funds error without sending payment

Fixes stakwork/sphinx-tribes#868

## Validation
- `node node_modules/jest/bin/jest.js src/people/WorkSpacePlanner/BountyCard/BountyCard.test.tsx --runInBand --no-coverage --silent`
- `git diff --check`