### PR TITLE
Prevent duplicate bounty submissions

### DIFF
--- a/src/people/main/FocusView.tsx
+++ b/src/people/main/FocusView.tsx
@@ -59,6 +59,7 @@ function FocusedView(props: FocusViewProps) {
   const [editable, setEditable] = useState<boolean>(!canEdit);
   const [isEditButtonDisable, setIsEditButtonDisable] = useState(false);
   const [toasts, setToasts]: any = useState([]);
+  const submitingRef = useRef(false);
 
   const scrollDiv: any = useRef(null);
   const formRef: any = useRef(null);
@@ -242,19 +243,26 @@ function FocusedView(props: FocusViewProps) {
 
   // eslint-disable-next-line @typescript-eslint/no-inferrable-types
   async function submitForm(body: any, notEdit?: boolean) {
-    if (submiting) return;
+    if (submitingRef.current) return;
+    submitingRef.current = true;
 
     try {
       let newBody = cloneDeep(body);
       newBody = await preSubmitFunctions(newBody);
 
-      if (!newBody) return; // avoid saving bad state
+      if (!newBody) {
+        submitingRef.current = false;
+        return;
+      } // avoid saving bad state
       if (!newBody.description) {
         addToast();
       }
 
       const info = ui.meInfo as any;
-      if (!info) return console.log('no meInfo');
+      if (!info) {
+        submitingRef.current = false;
+        return console.log('no meInfo');
+      }
       setLoading(true);
       setIsEditButtonDisable(true);
       setSubmiting(true);
@@ -302,6 +310,7 @@ function FocusedView(props: FocusViewProps) {
 
       setIsEditButtonDisable(false);
       setSubmiting(false);
+      submitingRef.current = false;
       if (props?.onSuccess) props.onSuccess();
 
       if (notEdit === true) {
@@ -314,6 +323,10 @@ function FocusedView(props: FocusViewProps) {
       )
         props?.ReCallBounties();
     } catch {
+      submitingRef.current = false;
+      setIsEditButtonDisable(false);
+      setSubmiting(false);
+      setLoading(false);
       setToasts([
         {
           id: '1',

--- a/src/people/main/__tests__/FocusView.spec.tsx
+++ b/src/people/main/__tests__/FocusView.spec.tsx
@@ -1,0 +1,105 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import FocusedView from '../FocusView';
+
+const mockMain = {
+  dropDownWorkspaces: [],
+  getBountyById: jest.fn(),
+  getPersonCreatedBounties: jest.fn(),
+  getUserDropdownWorkspaces: jest.fn(),
+  isTorSave: jest.fn(),
+  saveBounty: jest.fn()
+};
+
+const mockUi = {
+  meInfo: {
+    id: 1,
+    pubkey: 'current-user-pubkey',
+    owner_pubkey: 'current-user-pubkey'
+  },
+  setEditMe: jest.fn()
+};
+
+jest.mock('../../../store', () => ({
+  useStores: () => ({
+    main: mockMain,
+    ui: mockUi
+  })
+}));
+
+jest.mock('../../../store/ui', () => ({
+  uiStore: {
+    meInfo: { id: 1 }
+  }
+}));
+
+jest.mock('../../../store/bountyReviewStore', () => ({
+  bountyReviewStore: {
+    deleteBountyTiming: jest.fn()
+  }
+}));
+
+jest.mock('../../../components/common', () => ({
+  Button: ({ onClick, text }: any) => <button onClick={onClick}>{text}</button>,
+  IconButton: ({ onClick }: any) => <button onClick={onClick}>Back</button>,
+  useAfterDeleteNotification: () => ({ openAfterDeleteNotification: jest.fn() }),
+  useDeleteConfirmationModal: () => ({ openDeleteConfirmation: jest.fn() })
+}));
+
+jest.mock('../../../components/form/bounty', () => (props: any) => (
+  <button
+    onClick={() =>
+      props.onSubmit({
+        title: 'New bounty',
+        one_sentence_summary: '',
+        description: 'New description',
+        price: '2500',
+        assignee: '',
+        type: 'coding_task'
+      })
+    }
+  >
+    Save mocked bounty
+  </button>
+));
+
+jest.mock('../../widgetViews/summaries/WantedSummary', () => () => <div />);
+
+describe('FocusedView bounty submission guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMain.dropDownWorkspaces = [];
+    mockMain.getBountyById.mockResolvedValue([]);
+    mockMain.getUserDropdownWorkspaces.mockResolvedValue(undefined);
+    mockMain.isTorSave.mockReturnValue(false);
+  });
+
+  it('ignores duplicate clicks while a bounty save is in flight', async () => {
+    let resolveSave: () => void = jest.fn();
+    mockMain.saveBounty.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        })
+    );
+
+    render(
+      <FocusedView
+        config={{ schema: [], submitText: 'Save' }}
+        selectedIndex={-1}
+        canEdit={false}
+        person={{}}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Save mocked bounty'));
+    fireEvent.click(screen.getByText('Save mocked bounty'));
+
+    await waitFor(() => {
+      expect(mockMain.saveBounty).toHaveBeenCalledTimes(1);
+    });
+
+    resolveSave();
+  });
+});


### PR DESCRIPTION
Fixes stakwork/sphinx-tribes#1894

## Summary
- adds an immediate in-flight submit guard to the shared bounty form submit path
- prevents rapid duplicate clicks from calling `saveBounty` more than once before React state re-renders
- resets the guard on success, invalid early exits, and error paths
- adds a regression test for duplicate bounty save clicks while the first save is still pending

## Validation
- `node node_modules/jest/bin/jest.js src/people/main/__tests__/FocusView.spec.tsx --runInBand --no-coverage --silent`
- `git diff --check`