### PR TITLE
Add assigned-to-me bounty filter

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -13,6 +13,9 @@ function addMethod(m: string): (url: string, data?: any, incomingHeaders?: any) 
       const headers: { [key: string]: string } = {};
       const opts: { [key: string]: any } = { mode: 'cors' };
       headers['x-session-id'] = mainStore.getSessionId();
+      if (incomingHeaders) {
+        Object.assign(headers, incomingHeaders);
+      }
       console.log('Headers sesisonId: ', headers['x-session-id']);
       if (m === 'POST' || m === 'PUT') {
         if (!incomingHeaders) {

--- a/src/people/widgetViews/BountyHeader.tsx
+++ b/src/people/widgetViews/BountyHeader.tsx
@@ -18,6 +18,7 @@ import { PostBounty } from './postBounty';
 
 const Status = GetValue(status);
 const Coding_Languages = GetValue(coding_languages);
+const Assignment = [{ id: 'myAssigned', label: 'Assigned to me', value: 'myAssigned' }];
 
 interface styledProps {
   color?: any;
@@ -342,6 +343,7 @@ const BountyHeader = ({
   const color = colors['light'];
   const { main, ui } = useStores();
   const isMobile = useIsMobile();
+  const isAuthenticated = !!ui.meInfo?.tribe_jwt;
   const [peopleList, setPeopleList] = useState<Array<any> | null>(null);
   const [developerCount, setDeveloperCount] = useState<number>(0);
   const [activeBounty, setActiveBounty] = useState<Array<any> | number | null>(0);
@@ -569,6 +571,18 @@ const BountyHeader = ({
                       }}
                     />
                   </EuiPopOverCheckboxLeft>
+                  {isAuthenticated && (
+                    <EuiPopOverCheckboxLeft className="CheckboxOuter" color={color}>
+                      <EuiText className="leftBoxHeading">ASSIGNMENT</EuiText>
+                      <EuiCheckboxGroup
+                        options={Assignment}
+                        idToSelectedMap={checkboxIdToSelectedMap}
+                        onChange={(id: any) => {
+                          onChangeStatus(id);
+                        }}
+                      />
+                    </EuiPopOverCheckboxLeft>
+                  )}
                   <PopOverRightBox color={color}>
                     <EuiText className="rightBoxHeading">Tags</EuiText>
                     <EuiPopOverCheckboxRight className="CheckboxOuter" color={color}>
@@ -731,6 +745,18 @@ const BountyHeader = ({
                     }}
                   />
                 </EuiPopOverCheckboxLeft>
+                {isAuthenticated && (
+                  <EuiPopOverCheckboxLeft className="CheckboxOuter" color={color}>
+                    <EuiText className="leftBoxHeading">ASSIGNMENT</EuiText>
+                    <EuiCheckboxGroup
+                      options={Assignment}
+                      idToSelectedMap={checkboxIdToSelectedMap}
+                      onChange={(id: any) => {
+                        onChangeStatus(id);
+                      }}
+                    />
+                  </EuiPopOverCheckboxLeft>
+                )}
                 <PopOverRightBox color={color}>
                   <EuiText className="rightBoxHeading">Tags</EuiText>
                   <EuiPopOverCheckboxRight className="CheckboxOuter" color={color}>

--- a/src/people/widgetViews/__tests__/BountyHeader.spec.tsx
+++ b/src/people/widgetViews/__tests__/BountyHeader.spec.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom';
 import BountyHeader from '../BountyHeader';
 import { BountyHeaderProps } from '../../interfaces';
 import { mainStore } from '../../../store/main';
+import { uiStore } from '../../../store/ui';
 import * as hooks from '../../../hooks';
 
 const mockHistoryPush = jest.fn();
@@ -54,6 +55,7 @@ jest.mock('../../../hooks', () => ({
 describe('BountyHeader Component', () => {
   beforeEach(() => {
     jest.spyOn(mainStore, 'getBountyHeaderData').mockReset();
+    uiStore.setMeInfo(null as any);
     (hooks.useIsMobile as jest.Mock).mockReturnValue(false);
   });
 
@@ -79,6 +81,34 @@ describe('BountyHeader Component', () => {
   test('should render the filters', () => {
     render(<BountyHeader {...mockProps} />);
     expect(screen.getByText(/Filter/i)).toBeInTheDocument();
+  });
+
+  test('should show assigned-to-me filter for authenticated users', async () => {
+    const onChangeStatus = jest.fn();
+    uiStore.setMeInfo({
+      pubkey: 'test_pubkey',
+      owner_pubkey: 'test_pubkey',
+      tribe_jwt: 'test_jwt'
+    } as any);
+
+    render(<BountyHeader {...mockProps} onChangeStatus={onChangeStatus} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Filter search/i }));
+
+    expect(await screen.findByText('ASSIGNMENT')).toBeInTheDocument();
+    const assignedToMe = screen.getByRole('checkbox', { name: 'Assigned to me' });
+    fireEvent.click(assignedToMe);
+
+    expect(onChangeStatus).toHaveBeenCalledWith('myAssigned');
+  });
+
+  test('should hide assigned-to-me filter for unauthenticated users', () => {
+    render(<BountyHeader {...mockProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Filter search/i }));
+
+    expect(screen.queryByText('ASSIGNMENT')).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: 'Assigned to me' })).not.toBeInTheDocument();
   });
 
   test('should display the MobileFilterCount with correct number when filters are selected in mobile view', async () => {

--- a/src/store/__test__/main.spec.ts
+++ b/src/store/__test__/main.spec.ts
@@ -1257,6 +1257,38 @@ describe('Main store', () => {
     expect(store.peopleBounties[0].body.coding_languages).toEqual(filterCriteria.coding_languages);
   });
 
+  it('should send jwt when filtering bounties assigned to me', async () => {
+    const store = new MainStore();
+    const filterCriteria = {
+      limit: 25,
+      page: 1,
+      sortBy: 'created',
+      myAssigned: true
+    };
+
+    const apiResponse = {
+      status: 200,
+      ok: true,
+      json: async () => Promise.resolve([filterBounty])
+    };
+    fetchStub.callsFake((url: string, opts: RequestInit) => {
+      const urlObj = new URL(url);
+      const params = urlObj.searchParams;
+      const headers = opts?.headers as Headers;
+
+      expect(urlObj.origin).toBe(`http://${getHost()}`);
+      expect(urlObj.pathname).toBe('/gobounties/all');
+      expect(params.get('myAssigned')).toBe('true');
+      expect(headers.get('x-jwt')).toBe(user.tribe_jwt);
+
+      return Promise.resolve(apiResponse);
+    });
+
+    await store.getPeopleBounties(filterCriteria);
+
+    sinon.assert.calledOnce(fetchStub);
+  });
+
   it('should successfully fetch workspace users', async () => {
     const mockUsers: Person[] = [
       {

--- a/src/store/interface.ts
+++ b/src/store/interface.ts
@@ -183,6 +183,7 @@ export interface QueryParams {
   search?: string;
   resetPage?: boolean;
   languages?: string;
+  myAssigned?: boolean;
   org_uuid?: string;
   provider?: string;
   workspace?: string;
@@ -296,6 +297,7 @@ export interface BountyStatus {
   Paid: boolean;
   Pending: boolean;
   Failed: boolean;
+  myAssigned?: boolean;
 }
 
 export interface WorkspaceBudget {

--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -79,9 +79,14 @@ function makeQueryParams(limit: number, queryParams?: QueryParams): string {
     ...(queryParams?.resetPage ? { resetPage: String(queryParams.resetPage) } : {}),
     ...(queryParams?.page ? { page: String(queryParams.page) } : {}),
     ...(queryParams?.languages ? { languages: queryParams.languages } : {})
-  } as Record<string, string>;
+  } as Record<string, string | number | boolean | undefined>;
 
-  const searchParams = new URLSearchParams(adaptedParams);
+  const searchParams = new URLSearchParams();
+  Object.entries(adaptedParams).forEach(([key, value]) => {
+    if (value !== undefined) {
+      searchParams.set(key, String(value));
+    }
+  });
 
   return searchParams.toString();
 }
@@ -712,7 +717,11 @@ export class MainStore {
     const query2 = makeQueryParams(queryLimit, params ? queryParams : this.getWantedsPrevParams);
 
     try {
-      const ps2 = await api.get(`gobounties/all?${query2}`);
+      const jwtHeaders =
+        queryParams.myAssigned && uiStore.meInfo?.tribe_jwt
+          ? { 'x-jwt': uiStore.meInfo.tribe_jwt }
+          : undefined;
+      const ps2 = await api.get(`gobounties/all?${query2}`, undefined, jwtHeaders);
 
       const ps3: any[] = [];
 
@@ -1087,7 +1096,7 @@ export class MainStore {
       }
 
       const data = await response.json();
-      
+
       if (data && data.length) {
         const ps3: any[] = [];
         for (let i = 0; i < data.length; i++) {


### PR DESCRIPTION
## Summary
- Add an authenticated-only Assignment filter group to the Bounties page with an `Assigned to me` checkbox.
- Send `myAssigned=true` through the existing bounties query params and include the user's `x-jwt` header only for that filter.
- Cover the UI visibility/callback behavior and the store API request behavior with focused tests.

Fixes #925.
Depends on backend support in stakwork/sphinx-tribes#2791 for stakwork/sphinx-tribes#2436.

## Validation
- `REACT_APP_IS_TEST=true NODE_ENV=test node node_modules/jest/bin/jest.js --runTestsByPath src/store/__test__/main.spec.ts -t "should send jwt when filtering bounties assigned to me" --runInBand --no-coverage --silent`
- `REACT_APP_IS_TEST=true NODE_ENV=test node node_modules/jest/bin/jest.js --runTestsByPath src/people/widgetViews/__tests__/BountyHeader.spec.tsx --runInBand --no-coverage --silent --transformIgnorePatterns "./svg/"`
- `git diff --check`