### PR TITLE
Fix summary modal arrow styling

### DIFF
--- a/src/components/common/Modal.spec.tsx
+++ b/src/components/common/Modal.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import Modal from './Modal';
 
 describe('<Modal /> Arrow Buttons', () => {
@@ -17,5 +18,16 @@ describe('<Modal /> Arrow Buttons', () => {
     const nextArrow = screen.getByText('chevron_right');
     fireEvent.click(nextArrow);
     expect(nextArrowFunction).toHaveBeenCalled();
+  });
+
+  test('renders new arrow icon buttons without primary blue backgrounds', () => {
+    render(<Modal prevArrowNew={jest.fn()} nextArrowNew={jest.fn()} visible={true} />);
+
+    expect(screen.getByText('chevron_left').closest('button')).toHaveStyle({
+      background: '#ffffff00'
+    });
+    expect(screen.getByText('chevron_right').closest('button')).toHaveStyle({
+      background: '#ffffff00'
+    });
   });
 });

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -236,6 +236,10 @@ export default function Modal(props: ModalProps) {
             <LNew color={color}>
               <CircL color={color}>
                 <IconButton
+                  color="noColor"
+                  width={62}
+                  height={88}
+                  style={{ padding: 0 }}
                   iconStyle={{ color: color.pureWhite }}
                   icon={'chevron_left'}
                   onClick={(e: any) => {
@@ -250,6 +254,10 @@ export default function Modal(props: ModalProps) {
             <RNew color={color}>
               <CircR color={color}>
                 <IconButton
+                  color="noColor"
+                  width={62}
+                  height={88}
+                  style={{ padding: 0 }}
                   icon={'chevron_right'}
                   iconStyle={{ color: color.pureWhite }}
                   onClick={(e: any) => {


### PR DESCRIPTION
## Summary
- Make the summary modal's new left/right arrow buttons transparent inside the existing side-arrow containers instead of inheriting the primary blue button style.
- Pin the icon button dimensions to the side-arrow container and remove extra button padding so the arrows render as clean side controls.
- Add a focused Modal test covering the non-primary arrow background while preserving existing click behavior.

Addresses stakwork/sphinx-tribes#594.

## Validation
- `REACT_APP_IS_TEST=true NODE_ENV=test node node_modules/jest/bin/jest.js --runTestsByPath src/components/common/Modal.spec.tsx --runInBand --no-coverage --silent --transformIgnorePatterns "./svg/"`
- `git diff --check`