### PR TITLE
Add workspace tab viewer tests

### DIFF
--- a/src/people/widgetViews/__tests__/WorkspaceView.spec.tsx
+++ b/src/people/widgetViews/__tests__/WorkspaceView.spec.tsx
@@ -231,4 +231,46 @@ describe('WorkspaceView Component', () => {
       });
     });
   });
+
+  it('test signed-out viewers can view workspace bounties without manage actions', async () => {
+    const viewerWorkspace = {
+      ...workspaces[0],
+      bounty_count: 2
+    };
+
+    uiStore.setMeInfo(null as any);
+    jest.spyOn(mainStore, 'getUserRoles').mockReturnValue(Promise.resolve([]));
+    jest.spyOn(mainStore, 'getWorkspaceUser').mockReturnValue(Promise.resolve({} as any));
+    mainStore.setWorkspaces([viewerWorkspace]);
+
+    render(<WorkspaceView person={person} />);
+
+    const viewBountiesBtn = await screen.findByRole('button', {
+      name: 'View Bounties open_in_new_tab'
+    });
+
+    expect(viewBountiesBtn).toBeEnabled();
+    expect(screen.queryByRole('button', { name: 'Manage' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Add Workspace')).not.toBeInTheDocument();
+  });
+
+  it('test signed-in viewers on another profile cannot add or manage workspaces', async () => {
+    const otherPerson = {
+      ...person,
+      owner_pubkey: 'other-owner-pubkey'
+    };
+
+    uiStore.setMeInfo(user);
+    jest.spyOn(mainStore, 'getUserRoles').mockReturnValue(Promise.resolve([]));
+    jest.spyOn(mainStore, 'getWorkspaceUser').mockReturnValue(Promise.resolve({} as any));
+    mainStore.setWorkspaces([{ ...workspaces[0], bounty_count: 1 }]);
+
+    render(<WorkspaceView person={otherPerson} />);
+
+    expect(
+      await screen.findByRole('button', { name: 'View Bounties open_in_new_tab' })
+    ).toBeEnabled();
+    expect(screen.queryByText('Add Workspace')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Manage' })).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Add organization/workspace tab coverage for signed-out viewers.
- Add coverage for signed-in users viewing another profile.
- Assert viewer paths can still access View Bounties while Add Workspace and Manage actions stay hidden.

Addresses stakwork/sphinx-tribes#875.

## Validation
- `REACT_APP_IS_TEST=true NODE_ENV=test node node_modules/jest/bin/jest.js --runTestsByPath src/people/widgetViews/__tests__/WorkspaceView.spec.tsx --runInBand --no-coverage --silent --transformIgnorePatterns "./svg/"`
- `git diff --check`