### PR TITLE
[codex] Add workspace deposit modal test

### DIFF
--- a/src/people/widgetViews/__tests__/WorkspaceDetails.spec.tsx
+++ b/src/people/widgetViews/__tests__/WorkspaceDetails.spec.tsx
@@ -854,6 +854,26 @@ describe('WorkspaceDetails', () => {
     });
   });
 
+  it('opens deposit modal from organization budget actions', async () => {
+    render(
+      <MemoryRouter>
+        <WorkspaceDetails
+          close={closeFn}
+          getWorkspaces={getWorkspaceFn}
+          org={workspace}
+          resetWorkspace={resetWorkspaceFn}
+        />
+      </MemoryRouter>
+    );
+
+    const depositBtn = await screen.findByRole('button', { name: 'Deposit' });
+    fireEvent.click(depositBtn);
+
+    expect(await screen.findByRole('heading', { name: 'Deposit' })).toBeInTheDocument();
+    expect(screen.getByTestId('input-amount')).toBeInTheDocument();
+    expect(screen.getByTestId('generate-button')).toBeDisabled();
+  });
+
   it('should disable edit and add user button if user is not admin', async () => {
     jest.spyOn(mainStore, 'getPersonAssignedBounties').mockReturnValue(Promise.resolve([]));
     jest.spyOn(mainStore, 'pollWorkspaceBudgetInvoices').mockReturnValue(Promise.resolve([]));


### PR DESCRIPTION
## Summary
- add organization workspace coverage for the Deposit action opening the real deposit modal
- verify the deposit form heading, amount input, and disabled Generate Invoice state before an amount is entered

## Validation
- REACT_APP_IS_TEST=true NODE_ENV=test node node_modules/jest/bin/jest.js --runTestsByPath src/people/widgetViews/__tests__/WorkspaceDetails.spec.tsx --runInBand --no-coverage --silent --transformIgnorePatterns "./svg/"
- git diff --check

Refs stakwork/sphinx-tribes#870