### PR TITLE
[codex] Add profile bounty URL regression tests

### DIFF
--- a/src/pages/people/tabs/__tests__/Wanted.spec.tsx
+++ b/src/pages/people/tabs/__tests__/Wanted.spec.tsx
@@ -234,6 +234,7 @@ describe('Wanted Component', () => {
 
   test('should redirect to bounty page when bounty card is clicked', async () => {
     const mockPush = jest.fn();
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(jest.fn());
 
     jest.mock('react-router-dom', () => ({
       ...jest.requireActual('react-router-dom'),
@@ -282,9 +283,12 @@ describe('Wanted Component', () => {
       getAllByTestId('user-created-bounty')[0].click();
       expect(getAllByTestId('user-created-bounty').length).toBe(1);
       expect(getAllByTestId('user-created-bounty')[0].getAttribute('href')).toEqual(
-        `/p/1234/wanted/${userBounty.body.id}/0`
+        `/bounty/${userBounty.body.id}`
       );
+      expect(openSpy).toHaveBeenCalledWith(`/bounty/${userBounty.body.id}`, '_blank');
     });
+
+    openSpy.mockRestore();
   });
 
   test('should render status assigned if ticket is assigned', async () => {

--- a/src/people/widgetViews/__tests__/UserTicketsView.spec.tsx
+++ b/src/people/widgetViews/__tests__/UserTicketsView.spec.tsx
@@ -88,6 +88,30 @@ describe('UserTickets', () => {
     });
   });
 
+  it('links assigned bounty cards to the new bounty URL', async () => {
+    const userBounty = { ...mockBounties[0], body: {} } as any;
+    userBounty.body = {
+      ...mockBounties[0].bounty,
+      owner_id: person.owner_pubkey,
+      title: 'test bounty here'
+    } as any;
+    jest
+      .spyOn(mainStore, 'getPersonAssignedBounties')
+      .mockReturnValue(Promise.resolve([userBounty]));
+
+    await act(async () => {
+      const { getByTestId } = render(
+        <MemoryRouter initialEntries={['/p/1234/assigned']}>
+          <Route path="/p/:uuid/assigned" component={UserTickets} />
+        </MemoryRouter>
+      );
+
+      const bountyCard = await waitFor(() => getByTestId('user-personal-bounty-card'));
+
+      expect(bountyCard).toHaveAttribute('href', `/bounty/${userBounty.body.id}`);
+    });
+  });
+
   it('renders price matching the bounty', async () => {
     const userBounty = { ...mockBounties[0], body: {} } as any;
     userBounty.body = {


### PR DESCRIPTION
## Summary
- update the created-bounties profile test to expect the new `/bounty/:id` URL instead of the deprecated `/p/:uuid/wanted/:id/:index` URL
- assert the created bounty card opens `/bounty/:id` in a new tab
- add assigned-bounties profile coverage proving assigned bounty cards also link to `/bounty/:id`

## Validation
- REACT_APP_IS_TEST=true NODE_ENV=test node node_modules/jest/bin/jest.js --runTestsByPath src/pages/people/tabs/__tests__/Wanted.spec.tsx src/people/widgetViews/__tests__/UserTicketsView.spec.tsx --runInBand --no-coverage --silent --transformIgnorePatterns "./svg/"
- git diff --check

Refs stakwork/sphinx-tribes#979