### PR TITLE
Add social link preview meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,19 @@
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
-  <meta name="description" content="Public Chat Groups for Sphinx" />
+  <meta name="description" content="Find work, post bounties, and connect with builders in Sphinx Community." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Sphinx Community" />
+  <meta property="og:title" content="Sphinx Community" />
+  <meta property="og:description" content="Find work, post bounties, and connect with builders in Sphinx Community." />
+  <meta property="og:image" content="https://community.sphinx.chat/logo512.png" />
+  <meta property="og:image:width" content="512" />
+  <meta property="og:image:height" content="512" />
+  <meta property="og:url" content="https://community.sphinx.chat/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Sphinx Community" />
+  <meta name="twitter:description" content="Find work, post bounties, and connect with builders in Sphinx Community." />
+  <meta name="twitter:image" content="https://community.sphinx.chat/logo512.png" />
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- replace the bare default description with share-friendly Sphinx Community copy
- add Open Graph title, description, image, URL, and site metadata
- add Twitter card title, description, and image metadata

Fixes stakwork/sphinx-tribes#670

## Validation
- `git diff --check`
- PowerShell check that `og:title`, `og:description`, `og:image`, `twitter:card`, and `twitter:image` are present in `public/index.html`

## Notes
- This is a static metadata update to the CRA HTML template, so no app bundle behavior changed.