### PR TITLE
Use CSS ellipsis for tribe button names

### DIFF
--- a/src/bounties/BountyModalButtonSet.tsx
+++ b/src/bounties/BountyModalButtonSet.tsx
@@ -13,6 +13,13 @@ const ButtonSetContainer = styled.div`
   min-height: 300px;
 `;
 
+const TribeButtonText = styled(EuiText)`
+  max-width: 108px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
 const ButtonSet = ({ showGithubBtn, ...props }: any) => {
   const color = colors['light'];
   return (
@@ -100,9 +107,9 @@ const ButtonSet = ({ showGithubBtn, ...props }: any) => {
               width={'32px'}
             />
           </div>
-          <EuiText className="ButtonText">
-            {props.tribe.slice(0, 14)} {props.tribe.length > 14 && '...'}
-          </EuiText>
+          <TribeButtonText className="ButtonText" title={props.tribe}>
+            {props.tribe}
+          </TribeButtonText>
           <div className="ImageContainer">
             <img
               className="buttonImage"
@@ -133,11 +140,9 @@ const ButtonSet = ({ showGithubBtn, ...props }: any) => {
               width={'32px'}
             />
           </div>
-          <EuiText className="ButtonText">
-            {props.tribe
-              ? props.tribe.slice(0, 14) + (props.tribe.length > 14 ? '...' : '')
-              : 'No Tribe'}
-          </EuiText>
+          <TribeButtonText className="ButtonText" title={props.tribe || 'No Tribe'}>
+            {props.tribe || 'No Tribe'}
+          </TribeButtonText>
           <div className="ImageContainer">
             <img
               className="buttonImage"

--- a/src/bounties/__tests__/BountyModelButtonSet.spec.tsx
+++ b/src/bounties/__tests__/BountyModelButtonSet.spec.tsx
@@ -23,4 +23,13 @@ describe('BountyModalButtonSet Component', () => {
     const tribeButton = screen.getByText(/kotlin/i);
     expect(tribeButton).toBeInTheDocument();
   });
+
+  it('keeps long tribe names intact for CSS ellipsis', () => {
+    render(<ButtonSet tribe="Bounty Hunters Tribe" />);
+
+    const tribeButton = screen.getByText('Bounty Hunters Tribe');
+    expect(tribeButton).toBeInTheDocument();
+    expect(tribeButton).toHaveAttribute('title', 'Bounty Hunters Tribe');
+    expect(screen.queryByText('Bounty Hunters T...')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- stop manually slicing long tribe names in the bounty modal button set
- preserve the full tribe name in the DOM and `title` attribute
- apply CSS `text-overflow: ellipsis` to constrain the button label visually
- add a regression test for long tribe names

Fixes stakwork/sphinx-tribes#498

## Validation
- `REACT_APP_IS_TEST=true NODE_ENV=test node node_modules/jest/bin/jest.js --runTestsByPath src/bounties/__tests__/BountyModelButtonSet.spec.tsx --runInBand --no-coverage --silent --transformIgnorePatterns "./svg/"`
- `git diff --check`