### PR TITLE
Improve 404 route handling and coverage

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -11,8 +11,6 @@ server {
 
     autoindex off;
 
-    error_page 404 /index.html;
-
     location = /favicon.ico {
         log_not_found off;
         access_log off;
@@ -32,11 +30,9 @@ server {
 
     location / {
         try_files $uri $uri/ /index.html;
-        
-        add_header X-Not-Found $request_uri;
     }
 
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|json|txt|webp|woff|woff2)$ {
         expires max;
         log_not_found off;
         try_files $uri =404;

--- a/src/pages/notFound/index.spec.tsx
+++ b/src/pages/notFound/index.spec.tsx
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { NotFoundPage } from '.';
+
+const mockCapture = jest.fn();
+const mockPostHog = {
+  capture: mockCapture
+};
+
+jest.mock('posthog-js/react', () => ({
+  usePostHog: () => mockPostHog
+}));
+
+describe('NotFoundPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('tracks the missing route with the current path and search params', async () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/does-not-exist?source=test']
+    });
+
+    render(
+      <Router history={history}>
+        <NotFoundPage />
+      </Router>
+    );
+
+    await waitFor(() =>
+      expect(mockCapture).toHaveBeenCalledWith('not_found_page_view', {
+        path: '/does-not-exist',
+        search: '?source=test'
+      })
+    );
+  });
+
+  it('returns users to the home route', () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/missing-route']
+    });
+
+    render(
+      <Router history={history}>
+        <NotFoundPage />
+      </Router>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Take me back' }));
+
+    expect(history.location.pathname).toBe('/');
+  });
+});

--- a/src/pages/notFound/index.tsx
+++ b/src/pages/notFound/index.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { usePostHog } from 'posthog-js/react';
+import React, { useEffect } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import {
   NotFoundPageContainer,
   ContentWrapper,
@@ -14,6 +15,15 @@ import {
 
 export function NotFoundPage() {
   const history = useHistory();
+  const location = useLocation();
+  const posthog = usePostHog();
+
+  useEffect(() => {
+    posthog?.capture('not_found_page_view', {
+      path: location.pathname,
+      search: location.search
+    });
+  }, [location.pathname, location.search, posthog]);
 
   return (
     <NotFoundPageContainer>

--- a/src/pages/notFound/nginxConfig.spec.ts
+++ b/src/pages/notFound/nginxConfig.spec.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('nginx 404 handling config', () => {
+  const config = fs.readFileSync(path.join(process.cwd(), 'deploy', 'nginx.conf'), 'utf8');
+
+  it('serves the React app for direct SPA route access', () => {
+    expect(config).toContain('try_files $uri $uri/ /index.html;');
+  });
+
+  it('keeps missing static assets as nginx 404 responses', () => {
+    expect(config).toContain('location ~* \\.(js|css|png|jpg|jpeg|gif|ico|svg|json|txt|webp|woff|woff2)$');
+    expect(config).toContain('try_files $uri =404;');
+    expect(config).not.toContain('error_page 404 /index.html;');
+  });
+});


### PR DESCRIPTION
## Summary
- tracks NotFoundPage views with PostHog path/search metadata for client-side 404 visibility
- adds component coverage for the NotFound page tracking event and back-home action
- tightens nginx SPA fallback so direct React routes still serve `index.html` while missing static assets return nginx 404s
- adds nginx config coverage for SPA fallback and static asset 404 behavior

Fixes #1294

## Validation
- `REACT_APP_IS_TEST=true NODE_ENV=test node node_modules\jest\bin\jest.js --runTestsByPath src\pages\notFound\index.spec.tsx src\pages\notFound\nginxConfig.spec.ts --runInBand --no-coverage --silent --transformIgnorePatterns "./svg/"`
- `npx eslint src\pages\notFound\index.tsx src\pages\notFound\index.spec.tsx src\pages\notFound\nginxConfig.spec.ts --max-warnings 100`
- `git diff --check`