### PR TITLE
Improve toast and modal close controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -911,6 +911,15 @@ textarea.qr-string {
   width: 24px;
 }
 
+button[data-test-subj='toastCloseButton'] {
+  color: #3c3f41 !important;
+  opacity: 1 !important;
+}
+
+button[data-test-subj='toastCloseButton'] svg {
+  fill: currentColor !important;
+}
+
 @media (max-width: 767px) {
   #header-right {
     margin-top: 10px;

--- a/src/components/common/Modal.spec.tsx
+++ b/src/components/common/Modal.spec.tsx
@@ -18,4 +18,13 @@ describe('<Modal /> Arrow Buttons', () => {
     fireEvent.click(nextArrow);
     expect(nextArrowFunction).toHaveBeenCalled();
   });
+
+  test('renders the image close control as a clickable labelled button', () => {
+    const closeFunction = jest.fn();
+    render(<Modal bigCloseImage={closeFunction} visible={true} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+
+    expect(closeFunction).toHaveBeenCalled();
+  });
 });

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -97,6 +97,23 @@ const BigX = styled.div<styledProps>`
   cursor: pointer;
   z-index: 10;
 `;
+
+const BigCloseImageButton = styled.button<styledProps>`
+  position: absolute;
+  top: 8px;
+  right: -48px;
+  height: 40px;
+  width: 40px;
+  cursor: pointer;
+  z-index: 10;
+  border: none;
+  padding: 0;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
 const Env = styled.div<styledProps>`
   width: 312px;
   min-height: 254px;
@@ -183,22 +200,18 @@ export default function Modal(props: ModalProps) {
           )}
 
           {bigCloseImage && (
-            <div
+            <BigCloseImageButton
               data-testid="close-btn"
-              style={{
-                height: '40px',
-                width: '40px',
-                position: 'absolute',
-                top: '8px',
-                right: '-48px',
-                cursor: 'pointer',
-                zIndex: 10,
-                ...bigCloseImageStyle
+              type="button"
+              aria-label="Close modal"
+              style={bigCloseImageStyle}
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                e.stopPropagation();
+                bigCloseImage();
               }}
-              onClick={bigCloseImage}
             >
               <img src="/static/Close.svg" alt="close_svg" height={'100%'} width={'100%'} />
-            </div>
+            </BigCloseImageButton>
           )}
 
           {prevArrow && (


### PR DESCRIPTION
## Summary
- keeps EUI toast dismiss buttons visible with explicit color/opacity so the cross is no longer hidden until hover
- renders the shared image modal close control as a real labelled button with a reliable click target
- stops close-button clicks from bubbling through modal overlays
- adds Modal coverage for the labelled image close button path used by history-style pop-up cards

Fixes #105

## Validation
- `REACT_APP_IS_TEST=true NODE_ENV=test node node_modules\jest\bin\jest.js --runTestsByPath src\components\common\Modal.spec.tsx --runInBand --no-coverage --silent --transformIgnorePatterns "./svg/"`
- `npx eslint src\components\common\Modal.tsx src\components\common\Modal.spec.tsx --max-warnings 100`
- `git diff --check`