### PR TITLE
Add referral params to copied bounty links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect } from 'react';
 import '@material/react-material-icon/dist/material-icon.css';
 import history from 'config/history';
 import { withProviders } from 'providers';
-import { Router } from 'react-router-dom';
+import { Router, useLocation } from 'react-router-dom';
 import { uiStore } from 'store/ui';
 import './App.css';
 import { ThemeProvider, createTheme } from '@mui/system';
@@ -12,12 +12,23 @@ import { ModeDispatcher } from './config/ModeDispatcher';
 import { Pages } from './pages';
 import { appEnv } from './config/env';
 import { mainStore } from './store/main';
+import { persistReferralQuery } from './helpers/referral';
 
 let exchangeRateInterval: any = null;
 
 const theme = createTheme({
   spacing: 8
 });
+
+function ReferralTracker() {
+  const location = useLocation();
+
+  useEffect(() => {
+    persistReferralQuery(location.search);
+  }, [location.search]);
+
+  return null;
+}
 
 function App() {
   const posthog = usePostHog();
@@ -108,6 +119,7 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <Router history={history}>
+        <ReferralTracker />
         <ModeDispatcher>{(mode: any) => <Pages mode={mode} />}</ModeDispatcher>
       </Router>
     </ThemeProvider>

--- a/src/helpers/__test__/referral.spec.ts
+++ b/src/helpers/__test__/referral.spec.ts
@@ -1,0 +1,32 @@
+import { buildReferralUrl, persistReferralQuery, REFERRED_BY_KEY } from '../referral';
+
+describe('referral helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.history.pushState({}, '', '/bounties');
+  });
+
+  it('stores referral query values locally', () => {
+    expect(persistReferralQuery('?p=referrer-uuid&tab=bounties')).toBe('referrer-uuid');
+    expect(localStorage.getItem(REFERRED_BY_KEY)).toBe('referrer-uuid');
+  });
+
+  it('does not overwrite the stored referral when the query is missing', () => {
+    localStorage.setItem(REFERRED_BY_KEY, 'existing-referrer');
+
+    expect(persistReferralQuery('?tab=bounties')).toBeNull();
+    expect(localStorage.getItem(REFERRED_BY_KEY)).toBe('existing-referrer');
+  });
+
+  it('adds the signed-in user uuid to copied bounty links', () => {
+    expect(buildReferralUrl('/bounty/12', 'my-user-uuid')).toBe(
+      'http://localhost/bounty/12?p=my-user-uuid'
+    );
+  });
+
+  it('preserves existing query params when adding referral data', () => {
+    expect(buildReferralUrl('/bounty/12?foo=bar', 'my-user-uuid')).toBe(
+      'http://localhost/bounty/12?foo=bar&p=my-user-uuid'
+    );
+  });
+});

--- a/src/helpers/referral.ts
+++ b/src/helpers/referral.ts
@@ -1,0 +1,22 @@
+export const REFERRED_BY_KEY = 'referred_by';
+export const REFERRAL_PARAM = 'p';
+
+export function persistReferralQuery(search: string): string | null {
+  const params = new URLSearchParams(search);
+  const referredBy = params.get(REFERRAL_PARAM);
+
+  if (!referredBy) return null;
+
+  localStorage.setItem(REFERRED_BY_KEY, referredBy);
+  return referredBy;
+}
+
+export function buildReferralUrl(pathOrUrl: string, referrerUuid?: string): string {
+  const url = new URL(pathOrUrl, window.location.origin);
+
+  if (referrerUuid) {
+    url.searchParams.set(REFERRAL_PARAM, referrerUuid);
+  }
+
+  return url.toString();
+}

--- a/src/people/widgetViews/summaries/WantedSummary.tsx
+++ b/src/people/widgetViews/summaries/WantedSummary.tsx
@@ -13,6 +13,7 @@ import { useStores } from '../../../store';
 import { LanguageObject, awards } from '../../utils/languageLabelStyle';
 import NameTag from '../../utils/NameTag';
 import { sendToRedirect } from '../../../helpers';
+import { buildReferralUrl } from '../../../helpers/referral';
 import {
   CodingLanguageLabel,
   WantedSummaryProps,
@@ -375,7 +376,7 @@ function WantedSummary(props: WantedSummaryProps) {
   }
 
   const handleCopyUrl = () => {
-    navigator.clipboard.writeText(`${window.location.origin}${bountyPath}`);
+    navigator.clipboard.writeText(buildReferralUrl(bountyPath, ui.meInfo?.uuid));
     setIsCopied(true);
 
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- persist incoming `?p=<uuid>` referral query values in `localStorage` as `referred_by` from any routed page
- append the signed-in user uuid as `?p=<uuid>` when copying bounty links
- add focused helper tests for referral persistence and copied URL generation

Closes stakwork/sphinx-tribes-frontend#184.

## Validation
- `REACT_APP_IS_TEST=true NODE_ENV=test node node_modules\jest\bin\jest.js --runTestsByPath src\helpers\__test__\referral.spec.ts --runInBand --no-coverage --silent --transformIgnorePatterns "./svg/"`
- `npx eslint src\helpers\referral.ts src\helpers\__test__\referral.spec.ts src\App.tsx src\people\widgetViews\summaries\WantedSummary.tsx --max-warnings 100` (passes with existing App hook dependency warnings)
- `git diff --check`