### PR TITLE
Require workspace when creating bounties

### DIFF
--- a/src/components/form/__tests__/bountyWorkspaceRequired.spec.ts
+++ b/src/components/form/__tests__/bountyWorkspaceRequired.spec.ts
@@ -1,0 +1,22 @@
+import { BountyDetailsCreationData } from '../../../people/utils/BountyCreationConstant';
+import { wantedCodingTaskSchema } from '../schema';
+import { validator } from '../utils';
+
+describe('bounty workspace requirement', () => {
+  it('marks the workspace field as required in the bounty schema', async () => {
+    const workspaceField = wantedCodingTaskSchema.find((field) => field.name === 'org_uuid');
+
+    expect(workspaceField).toMatchObject({
+      label: 'Workspace *',
+      required: true
+    });
+
+    await expect(validator(wantedCodingTaskSchema).validateAt('org_uuid', {})).rejects.toThrow(
+      'Required'
+    );
+  });
+
+  it('blocks the first bounty creation step until workspace is selected', () => {
+    expect(BountyDetailsCreationData.step_2.required).toContain('org_uuid');
+  });
+});

--- a/src/components/form/schema.ts
+++ b/src/components/form/schema.ts
@@ -675,10 +675,11 @@ export const wantedOtherSchema: FormField[] = [
 export const wantedCodingTaskSchema: FormField[] = [
   {
     name: 'org_uuid',
-    label: 'Workspace (optional)',
+    label: 'Workspace *',
     type: 'select',
     options: [],
-    validator: strValidatorNotRequired,
+    required: true,
+    validator: strValidator,
     testId: 'Workspace'
   },
   {

--- a/src/people/utils/BountyCreationConstant.ts
+++ b/src/people/utils/BountyCreationConstant.ts
@@ -23,7 +23,7 @@ export const BountyDetailsCreationData = {
     sub_heading: ' ',
     schema: ['org_uuid', 'one_sentence_summary', 'ticket_url', 'phase_uuid', 'feature_uuid'],
     schema2: ['wanted_type', 'coding_languages'],
-    required: ['one_sentence_summary', 'wanted_type'],
+    required: ['org_uuid', 'one_sentence_summary', 'wanted_type'],
     outerContainerStyle: {
       minWidth: '712px', // Retains the current minimum width
       maxWidth: 'min(75vw, calc(712px * 2.5))', // 2.5x the minimum width (712 * 2.5 = 1780)

--- a/src/people/widgetViews/postBounty/__tests__/PostModal.spec.tsx
+++ b/src/people/widgetViews/postBounty/__tests__/PostModal.spec.tsx
@@ -51,7 +51,7 @@ describe('Post bounty modal', () => {
     const startButton = screen.getByText('Start');
     fireEvent.click(startButton);
     expect(screen.getByText('Basic info')).toBeInTheDocument();
-    const Form1 = screen.getByText('Workspace (optional)');
+    const Form1 = screen.getByText('Workspace *');
     const Form2 = screen.getByText('Bounty Title *');
     const Form3 = screen.getByText('Github Issue URL');
     const Form4 = screen.getByText('Category *');


### PR DESCRIPTION
## Summary
- make the bounty creation workspace select visibly required
- require `org_uuid` in both Formik/Yup validation and the multi-step Next-button gating
- update modal coverage and add a focused schema regression test

Closes stakwork/sphinx-tribes-frontend#644.

## Validation
- `REACT_APP_IS_TEST=true NODE_ENV=test node node_modules\jest\bin\jest.js --runTestsByPath src\components\form\__tests__\bountyWorkspaceRequired.spec.ts --runInBand --no-coverage --silent --transformIgnorePatterns "./svg/"`
- `REACT_APP_IS_TEST=true NODE_ENV=test node node_modules\jest\bin\jest.js --runTestsByPath src\people\widgetViews\postBounty\__tests__\PostModal.spec.tsx --runInBand --no-coverage --silent --transformIgnorePatterns "./svg/"`
- `REACT_APP_IS_TEST=true NODE_ENV=test node node_modules\jest\bin\jest.js --runTestsByPath src\components\form\bounty\bountyCreation.spec.tsx --runInBand --no-coverage --silent --transformIgnorePatterns "./svg/"`
- `npx eslint src\components\form\schema.ts src\components\form\__tests__\bountyWorkspaceRequired.spec.ts src\people\utils\BountyCreationConstant.ts src\people\widgetViews\postBounty\__tests__\PostModal.spec.tsx --max-warnings 100`
- `git diff --check`