### PR TITLE
Add Cypress workspace image creation flow

### DIFF
--- a/cypress/e2e/26_createOrgWithImage.cy.ts
+++ b/cypress/e2e/26_createOrgWithImage.cy.ts
@@ -1,0 +1,22 @@
+describe('Create Workspace With Image', () => {
+  it('creates a workspace with an uploaded image', () => {
+    const workspace: Cypress.Workspace = {
+      loggedInAs: 'carol',
+      name: 'New Workspace With Image',
+      description: 'We are testing workspace image upload during creation',
+      website: 'https://community.sphinx.chat',
+      github: 'https://github.com/stakwork/sphinx-tribes-frontend',
+      imageFileName: 'workspace-logo.png'
+    };
+
+    cy.login(workspace.loggedInAs);
+    cy.wait(1000);
+
+    cy.create_workspace(workspace);
+
+    cy.contains('Sucessfully created workspace').should('exist');
+    cy.contains(workspace.name).should('exist');
+
+    cy.logout(workspace.loggedInAs);
+  });
+});

--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -52,6 +52,7 @@ declare namespace Cypress {
     website?: string;
     github?: string;
     feature_call?: string;
+    imageFileName?: string;
   };
 
   type InvoiceDetail = {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -41,6 +41,17 @@ import { bech32 } from 'bech32';
 const EC = require('elliptic').ec;
 
 const v2AdminToken = 'xyzxyzxyz';
+const workspaceLogoPngBase64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+function getWorkspaceLogoFile(fileName = 'workspace-logo.png') {
+  return {
+    contents: Cypress.Buffer.from(workspaceLogoPngBase64, 'base64'),
+    fileName,
+    mimeType: 'image/png',
+    lastModified: Date.now()
+  };
+}
 
 Cypress.Commands.add('login', (userAlias: string) => {
   let user;
@@ -431,6 +442,12 @@ Cypress.Commands.add('create_workspace', (workspace) => {
 
   if (workspace.github) {
     cy.get('[placeholder="Github link..."]').type(workspace.github);
+  }
+
+  if (workspace.imageFileName) {
+    cy.get('#file-input').selectFile(getWorkspaceLogoFile(workspace.imageFileName), {
+      force: true
+    });
   }
 
   cy.contains('* Required fields').next().click();


### PR DESCRIPTION
## Summary
- extend `cy.create_workspace` with an optional in-memory PNG upload via the real workspace file input
- add Cypress coverage for creating an organization/workspace with an uploaded image
- document the optional image filename in the Cypress workspace command type

Closes stakwork/sphinx-tribes-frontend#427.

## Validation
- `npx tsc --noEmit --target es2015 --types cypress,node --moduleResolution node cypress\global.d.ts cypress\support\commands.ts cypress\e2e\26_createOrgWithImage.cy.ts`
- `npx eslint cypress\e2e\26_createOrgWithImage.cy.ts --max-warnings 100`
- `git diff --check`

Note: full `npx tsc -p cypress\tsconfig.json --noEmit` is currently blocked by existing unrelated Cypress project type errors, including `10_payBounty.cy.ts` using `"Less than 3 hour"`, missing fixture module declarations, and dependency private identifiers under the ES5 Cypress target.