### PR TITLE
Add Cypress workspace image edit flow

### DIFF
--- a/cypress/e2e/27_editOrganizationImage.cy.ts
+++ b/cypress/e2e/27_editOrganizationImage.cy.ts
@@ -1,0 +1,44 @@
+const workspaceLogoPngBase64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+describe("Edit Organization's Image", () => {
+  const workspace: Cypress.Workspace = {
+    loggedInAs: 'alice',
+    name: 'Workspace Image Edit',
+    description: 'A workspace for testing image edits.',
+    website: 'https://original.example'
+  };
+
+  it("edits an organization's image from the workspace edit modal", () => {
+    cy.login(workspace.loggedInAs);
+    cy.wait(1000);
+
+    cy.create_workspace(workspace);
+    cy.wait(1000);
+
+    cy.contains(workspace.name).get(`[data-work-name="${workspace.name}"]`).click();
+    cy.wait(1000);
+
+    cy.contains(/^Edit$/).click();
+    cy.wait(1000);
+
+    cy.get('#file-input').selectFile(
+      {
+        contents: Cypress.Buffer.from(workspaceLogoPngBase64, 'base64'),
+        fileName: 'updated-workspace-logo.png',
+        mimeType: 'image/png',
+        lastModified: Date.now()
+      },
+      { force: true }
+    );
+    cy.get('img[alt="selected file"]').should('exist');
+
+    cy.get('[data-testid="website"]').clear().type('https://updated.example');
+    cy.contains('Save changes').click();
+    cy.wait(600);
+
+    cy.contains('Sucessfully updated workspace');
+
+    cy.logout(workspace.loggedInAs);
+  });
+});


### PR DESCRIPTION
## Summary
- add Cypress coverage for editing an organization/workspace image through the edit modal file input
- use an in-memory PNG so the spec does not need a binary fixture
- assert the selected image preview appears before saving the updated workspace

Closes stakwork/sphinx-tribes-frontend#428.

## Validation
- `npx tsc --noEmit --target es2015 --types cypress,node --moduleResolution node cypress\global.d.ts cypress\e2e\27_editOrganizationImage.cy.ts`
- `npx eslint cypress\e2e\27_editOrganizationImage.cy.ts --max-warnings 100`
- `git diff --check`