### PR TITLE
Add Cypress profile details edit flow

### DIFF
--- a/cypress/e2e/14_edit_profile_details.cy.ts
+++ b/cypress/e2e/14_edit_profile_details.cy.ts
@@ -1,0 +1,29 @@
+describe('Edit Profile Details', () => {
+  it('edits profile description, socials, and coding languages', () => {
+    const userAlias = 'carol';
+    const description = 'Updated Cypress profile description';
+    const twitter = 'cypress_profile';
+    const github = 'cypress-profile';
+
+    cy.login(userAlias);
+    cy.wait(1000);
+
+    cy.contains(userAlias).click();
+    cy.contains('Edit Profile').click();
+
+    cy.contains('label', 'Description').parent().find('textarea').clear().type(description);
+    cy.contains('label', 'Twitter').parent().find('input').clear().type(twitter);
+    cy.contains('label', 'Github').parent().find('input').clear().type(github);
+
+    cy.contains('Coding Languages').click({ force: true });
+    cy.contains('Javascript').click({ force: true });
+    cy.contains('Coding Languages').click({ force: true });
+
+    cy.contains('Save').click();
+
+    cy.contains('Saved.').should('exist');
+    cy.contains(description).should('exist');
+
+    cy.logout(userAlias);
+  });
+});


### PR DESCRIPTION
## Summary
- add Cypress coverage for editing profile description, Twitter, Github, and coding language fields
- assert the profile save toast and updated description after saving

Closes stakwork/sphinx-tribes-frontend#401.

## Validation
- `npx tsc --noEmit --target es2015 --types cypress,node --moduleResolution node cypress\global.d.ts cypress\e2e\14_edit_profile_details.cy.ts`
- `npx eslint cypress\e2e\14_edit_profile_details.cy.ts --max-warnings 100`
- `git diff --check`