### PR TITLE
Add Cypress profile image and price edit flow

### DIFF
--- a/cypress/e2e/25_editProfileImageAndPrice.cy.ts
+++ b/cypress/e2e/25_editProfileImageAndPrice.cy.ts
@@ -1,0 +1,33 @@
+const profileImagePngBase64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+describe('Edit Profile Image And Price To Meet', () => {
+  it('edits profile image and price to meet', () => {
+    const userAlias = 'carol';
+    const priceToMeet = '1234';
+
+    cy.login(userAlias);
+    cy.wait(1000);
+
+    cy.contains(userAlias).click();
+    cy.contains('Edit Profile').click();
+
+    cy.get('input[type="file"]').selectFile(
+      {
+        contents: Cypress.Buffer.from(profileImagePngBase64, 'base64'),
+        fileName: 'profile-avatar.png',
+        mimeType: 'image/png',
+        lastModified: Date.now()
+      },
+      { force: true }
+    );
+
+    cy.contains('label', 'Price to Meet').parent().find('input').clear().type(priceToMeet);
+
+    cy.contains('Save').click();
+
+    cy.contains('Saved.').should('exist');
+
+    cy.logout(userAlias);
+  });
+});


### PR DESCRIPTION
## Summary
- add Cypress coverage for editing a profile image through the existing file input
- update price-to-meet in the same edit profile flow
- assert the profile save toast after saving

Closes stakwork/sphinx-tribes-frontend#426.

## Validation
- `npx tsc --noEmit --target es2015 --types cypress,node --moduleResolution node cypress\global.d.ts cypress\e2e\25_editProfileImageAndPrice.cy.ts`
- `npx eslint cypress\e2e\25_editProfileImageAndPrice.cy.ts --max-warnings 100`
- `git diff --check`